### PR TITLE
Rename Podspec to OktaLogger

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = "okta-logger-swift"
+  s.name             = "OktaLogger"
   s.version          = "0.9.0"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK"

--- a/OktaLogger.xcworkspace/contents.xcworkspacedata
+++ b/OktaLogger.xcworkspace/contents.xcworkspacedata
@@ -5,7 +5,7 @@
       location = "group:README.md">
    </FileRef>
    <FileRef
-      location = "group:okta-logger-swift.podspec">
+      location = "group:OktaLogger.podspec">
    </FileRef>
    <FileRef
       location = "group:Podfile">

--- a/Podfile
+++ b/Podfile
@@ -1,9 +1,6 @@
 platform :ios, '11.0'
 
 target 'OktaLogger' do
-    
-    pod 'okta-logger-swift', :path=> '.'
-    
     target 'OktaLoggerTests' do
         inherit! :search_paths
     end


### PR DESCRIPTION
Podspec was previously named okta-logger-swift, which causes
import lines to be okta_logger_swift, not very nice. Use latest naming scheme "OktaLogger"

Resolves: OKTA-300160

Reviewers: @IldarAbdullin-okta @lihaoli-okta @umangshah-okta @okta/ios 