### PR TITLE
Add Firebase Crashlytics logger.

### DIFF
--- a/Example/Example-iOS/AppDelegate.swift
+++ b/Example/Example-iOS/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import OktaLogger
+import Firebase
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,8 +16,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         let console = OktaLoggerConsoleLogger(identifier: "com.okta.OktaLoggerDemoApp.logger", level: .all, defaultProperties: nil)
-        OktaLogger.main = OktaLogger(destinations: [console])
+        let firebaseCrashlytics = initializeFirebaseCrashlyticsLogger()
+        OktaLogger.main = OktaLogger(destinations: [console, firebaseCrashlytics])
         return true
     }
 
+    func initializeFirebaseCrashlyticsLogger() -> OktaLoggerCrashlyticsLogger {
+        FirebaseApp.configure()
+        let crashlytics = Crashlytics.crashlytics()
+        crashlytics.setUserID("test123")
+
+        return OktaLoggerCrashlyticsLogger(
+            crashlytics: crashlytics,
+            identifier: "com.okta.OktaLoggerDemoApp.crashlyticsLogger",
+            level: .all
+        )
+    }
 }

--- a/Example/Example-iOS/ViewController.swift
+++ b/Example/Example-iOS/ViewController.swift
@@ -11,14 +11,16 @@ import OktaLogger
 
 class ViewController: UITableViewController {
     private let consoleLogCellTexts = ["Log debug message", "Log info message", "Log warning message", "Log UI event message", "Log error message"]
+    private let logEventNames = ["test-debug", "test-info", "test-warning", "test-ui", "test-error"]
     private let logLevelCellTexts = ["off", "debug", "info", "warning", "uiEvent", "error", "all"]
     private let logLevels: [OktaLoggerLogLevel] = [.off, .debug, .info, .warning, .uiEvent, .error, .all]
     private var logLevelSelectedIndex = 6
     private let logLevelSection = 0
     private let consoleLogSection = 1
+    private let crashSection = 2
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return 3
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -27,6 +29,8 @@ class ViewController: UITableViewController {
             return logLevelCellTexts.count
         case consoleLogSection:
             return consoleLogCellTexts.count
+        case crashSection:
+            return 1
         default:
             return 0
         }
@@ -47,6 +51,11 @@ class ViewController: UITableViewController {
             let cell = tableView.dequeueReusableCell(withIdentifier: "LoggerLevelTableCell", for: indexPath)
             cell.textLabel?.text = consoleLogCellTexts[indexPath.row]
             return cell
+        case crashSection:
+            let cell = tableView.dequeueReusableCell(withIdentifier: "LoggerLevelTableCell", for: indexPath)
+            cell.textLabel?.text = "Force a crash"
+            cell.textLabel?.textColor = UIColor.red
+            return cell
         default:
             return UITableViewCell()
         }
@@ -62,18 +71,20 @@ class ViewController: UITableViewController {
         case consoleLogSection:
             switch indexPath.row {
             case 0:
-                OktaLogger.main?.debug(eventName: consoleLogCellTexts[indexPath.row], message: nil)
+                OktaLogger.main?.debug(eventName: logEventNames[indexPath.row], message: consoleLogCellTexts[indexPath.row])
             case 1:
-                OktaLogger.main?.info(eventName: consoleLogCellTexts[indexPath.row], message: nil)
+                OktaLogger.main?.info(eventName: logEventNames[indexPath.row], message: consoleLogCellTexts[indexPath.row])
             case 2:
-                OktaLogger.main?.warning(eventName: consoleLogCellTexts[indexPath.row], message: nil)
+                OktaLogger.main?.warning(eventName: logEventNames[indexPath.row], message: consoleLogCellTexts[indexPath.row])
             case 3:
-                OktaLogger.main?.uiEvent(eventName: consoleLogCellTexts[indexPath.row], message: nil)
+                OktaLogger.main?.uiEvent(eventName: logEventNames[indexPath.row], message: consoleLogCellTexts[indexPath.row])
             case 4:
-                OktaLogger.main?.error(eventName: consoleLogCellTexts[indexPath.row], message: nil)
+                OktaLogger.main?.error(eventName: logEventNames[indexPath.row], message: consoleLogCellTexts[indexPath.row])
             default:
                 break
             }
+        case crashSection:
+            fatalError("Test fatal error")
         default:
             break
         }
@@ -85,6 +96,8 @@ class ViewController: UITableViewController {
             return "Change log level"
         case consoleLogSection:
             return "Log Message"
+        case crashSection:
+            return "Crash analytics"
         default:
             return nil
         }

--- a/GoogleService-Info.plist
+++ b/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>362037484104-u0olgmnna5m2cshji6i8cps3uf6lbv0a.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.362037484104-u0olgmnna5m2cshji6i8cps3uf6lbv0a</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDUXnkFQWL7hHThLY0pbM2I2qf-kbP2QIA</string>
+	<key>GCM_SENDER_ID</key>
+	<string>362037484104</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.okta.OktaLoggerDemoApp</string>
+	<key>PROJECT_ID</key>
+	<string>okta-logger-demo</string>
+	<key>STORAGE_BUCKET</key>
+	<string>okta-logger-demo.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:362037484104:ios:0ac0cf77e5292b8847967d</string>
+	<key>DATABASE_URL</key>
+	<string>https://okta-logger-demo.firebaseio.com</string>
+</dict>
+</plist>

--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.0.3"
+  s.version          = "1.0.4"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -12,24 +12,36 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.dependency 'SwiftLint'
   s.default_subspec = "Complete"
+  s.static_framework = true
 
   # Subspec
   s.subspec "Complete" do |complete|
     complete.dependency 'OktaLogger/Lumberjack'
+    complete.dependency 'OktaLogger/FirebaseCrashlytics'
   end
+
   s.subspec 'Lumberjack' do |lumberjack|
       lumberjack.source_files = [
         'OktaLogger/**/Lumberjack*.{h,m,swift}'
       ]
-      lumberjack.dependency  'CocoaLumberjack/Swift', '~>3.6.0'
+      lumberjack.dependency 'CocoaLumberjack/Swift', '~>3.6.0'
       lumberjack.dependency 'OktaLogger/Core'
+  end
+
+  s.subspec 'FirebaseCrashlytics' do |crashlytics|
+    crashlytics.source_files = [
+      'OktaLogger/CrashlyticsLogger/OktaLoggerCrashlyticsLogger.swift'
+    ]
+    crashlytics.dependency 'Firebase/Crashlytics', '~>6.29.0'
+    crashlytics.dependency 'OktaLogger/Core'
   end
 
   s.subspec "Core" do |core|
       core.source_files = 'OktaLogger/*.{h,m,swift}'
       core.exclude_files = [
         'OktaLogger/Info.plist',
-        'OktaLogger/FileLoggers'
+        'OktaLogger/FileLoggers',
+        'OktaLogger/CrashlyticsLogger'
       ]
   end
 

--- a/OktaLogger.xcodeproj/project.pbxproj
+++ b/OktaLogger.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,17 +12,13 @@
 		8004832A24C0FEE1008BFF3A /* FileLoggerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8004832924C0FEE1008BFF3A /* FileLoggerViewController.swift */; };
 		8004832C24C105AE008BFF3A /* LogLevelPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8004832B24C105AE008BFF3A /* LogLevelPicker.swift */; };
 		8004832E24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8004832D24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift */; };
-		804F18F224C00B1A00894A52 /* OktaLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C824D42469DBF1005CF747 /* OktaLogger.framework */; };
-		804F18F324C00B1A00894A52 /* OktaLogger.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D5C824D42469DBF1005CF747 /* OktaLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		804F18F424C00B1C00894A52 /* Pods_OktaLoggerDemoApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 330F4ED2C904A636A557BACB /* Pods_OktaLoggerDemoApp.framework */; };
-		804F18F524C00B1C00894A52 /* Pods_OktaLoggerDemoApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 330F4ED2C904A636A557BACB /* Pods_OktaLoggerDemoApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		804F18F724C0174800894A52 /* OktaLoggerFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804F18F624C0174800894A52 /* OktaLoggerFileLoggerTests.swift */; };
 		806FF25E24B95A3300994D4D /* OktaLoggerFileLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806FF25D24B95A3300994D4D /* OktaLoggerFileLogger.swift */; };
 		80AA10FC24BE603600981074 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10FB24BE603600981074 /* HomeViewController.swift */; };
 		80AA110024BE731900981074 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10FF24BE731900981074 /* Constants.swift */; };
 		80AA110224BE799800981074 /* FeatureTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA110124BE799800981074 /* FeatureTableViewCell.swift */; };
-		80C36E4C4B7E9BADC897EAF4 /* Pods_OktaLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1D77AAC14E07DCDBE81568 /* Pods_OktaLogger.framework */; };
-		8F809E70838C921EFE2420C3 /* Pods_OktaLoggerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AD139D0E38251CA2C4842F3 /* Pods_OktaLoggerTests.framework */; };
+		B3E071E3B33C4657A8B4381B /* libPods-OktaLogger.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 62BB891524DBDEF8FC8E9711 /* libPods-OktaLogger.a */; };
+		C4AA0759EDAC342A3B6B6796 /* libPods-OktaLoggerTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFB48B8C0D4F4DD1D258FFD /* libPods-OktaLoggerTests.a */; };
 		D52C2AD12474A4F5003CCF4D /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52C2AD02474A4F5003CCF4D /* ReadWriteLock.swift */; };
 		D54461C12469FFBA00C755F1 /* OktaLoggerLogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54461C02469FFBA00C755F1 /* OktaLoggerLogLevel.swift */; };
 		D54461C3246A023000C755F1 /* OktaLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54461C2246A023000C755F1 /* OktaLogger.swift */; };
@@ -36,23 +32,26 @@
 		D5C824E32469DBF1005CF747 /* OktaLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C824E22469DBF1005CF747 /* OktaLoggerTests.swift */; };
 		D5C824E52469DBF1005CF747 /* OktaLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = D5C824D72469DBF1005CF747 /* OktaLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5D0978E246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */; };
+		DEC5276624DBF9630022B698 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DEC5276524DBF9630022B698 /* GoogleService-Info.plist */; };
+		DEFB59E124EAC76400A1744F /* OktaLoggerCrashlyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB59E024EAC76300A1744F /* OktaLoggerCrashlyticsLogger.swift */; };
 		E251E7FE248AD1B400EF466D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E7FD248AD1B400EF466D /* AppDelegate.swift */; };
 		E251E800248AD1B400EF466D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E7FF248AD1B400EF466D /* SceneDelegate.swift */; };
 		E251E802248AD1B400EF466D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E801248AD1B400EF466D /* ViewController.swift */; };
 		E251E805248AD1B400EF466D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E251E803248AD1B400EF466D /* Main.storyboard */; };
 		E251E807248AD1B800EF466D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E251E806248AD1B800EF466D /* Assets.xcassets */; };
 		E251E80A248AD1B800EF466D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E251E808248AD1B800EF466D /* LaunchScreen.storyboard */; };
+		E3A717E14689E6EB7A6A088B /* libPods-OktaLoggerDemoApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DF75E3D21D2B9A971A2CAEC7 /* libPods-OktaLoggerDemoApp.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		80DDE78F24B967DB00D0E2F3 /* PBXContainerItemProxy */ = {
+		D54461C4246A02C800C755F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D5C824CB2469DBF1005CF747 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = D5C824D32469DBF1005CF747;
 			remoteInfo = OktaLogger;
 		};
-		D54461C4246A02C800C755F1 /* PBXContainerItemProxy */ = {
+		DE5D6F5724E6D05500AD95FD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D5C824CB2469DBF1005CF747 /* Project object */;
 			proxyType = 1;
@@ -68,8 +67,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				804F18F524C00B1C00894A52 /* Pods_OktaLoggerDemoApp.framework in Embed Frameworks */,
-				804F18F324C00B1A00894A52 /* OktaLogger.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -88,11 +85,16 @@
 
 /* Begin PBXFileReference section */
 		00EF841BC9AECECB76C176FE /* Pods-OktaLoggerDemoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLoggerDemoApp.release.xcconfig"; path = "Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp.release.xcconfig"; sourceTree = "<group>"; };
-		0AD139D0E38251CA2C4842F3 /* Pods_OktaLoggerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OktaLoggerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		028D1912AB9DB1ABBDD5EC94 /* Pods-OktaLogger.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLogger.release.xcconfig"; path = "Target Support Files/Pods-OktaLogger/Pods-OktaLogger.release.xcconfig"; sourceTree = "<group>"; };
 		1626D76D3FE5CD1504C6A51A /* Pods-OktaLoggerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLoggerTests.release.xcconfig"; path = "Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests.release.xcconfig"; sourceTree = "<group>"; };
+		2212750F97DBDF374821CF2C /* Pods-OktaLogger_.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLogger_.release.xcconfig"; path = "Target Support Files/Pods-OktaLogger_/Pods-OktaLogger_.release.xcconfig"; sourceTree = "<group>"; };
+		2BE105519632BEE1AAED7056 /* Pods-OktaLogger.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLogger.debug.xcconfig"; path = "Target Support Files/Pods-OktaLogger/Pods-OktaLogger.debug.xcconfig"; sourceTree = "<group>"; };
 		330F4ED2C904A636A557BACB /* Pods_OktaLoggerDemoApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OktaLoggerDemoApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4FFB48B8C0D4F4DD1D258FFD /* libPods-OktaLoggerTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OktaLoggerTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		62BB891524DBDEF8FC8E9711 /* libPods-OktaLogger.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OktaLogger.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6582AABCF4A4B6E5E05FC2E4 /* LumberjackLoggerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LumberjackLoggerDelegate.swift; sourceTree = "<group>"; };
 		6582ABCA2C9C2759535A1B4E /* FileLoggerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLoggerDelegate.swift; sourceTree = "<group>"; };
+		672ADCC5504F41DBB4546AB0 /* Pods-OktaLogger_.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLogger_.debug.xcconfig"; path = "Target Support Files/Pods-OktaLogger_/Pods-OktaLogger_.debug.xcconfig"; sourceTree = "<group>"; };
 		8004832924C0FEE1008BFF3A /* FileLoggerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLoggerViewController.swift; sourceTree = "<group>"; };
 		8004832B24C105AE008BFF3A /* LogLevelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevelPicker.swift; sourceTree = "<group>"; };
 		8004832D24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLoggerConfig.swift; sourceTree = "<group>"; };
@@ -102,9 +104,7 @@
 		80AA10FF24BE731900981074 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		80AA110124BE799800981074 /* FeatureTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureTableViewCell.swift; sourceTree = "<group>"; };
 		80DDE79324B972FC00D0E2F3 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
-		8F19A5AD43A044835A9DE194 /* Pods-OktaLogger.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLogger.debug.xcconfig"; path = "Target Support Files/Pods-OktaLogger/Pods-OktaLogger.debug.xcconfig"; sourceTree = "<group>"; };
 		C58A9E54B6CE1A902894264C /* Pods-OktaLoggerDemoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLoggerDemoApp.debug.xcconfig"; path = "Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp.debug.xcconfig"; sourceTree = "<group>"; };
-		CD1D77AAC14E07DCDBE81568 /* Pods_OktaLogger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OktaLogger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D52C2AD02474A4F5003CCF4D /* ReadWriteLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		D54461C02469FFBA00C755F1 /* OktaLoggerLogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerLogLevel.swift; sourceTree = "<group>"; };
 		D54461C2246A023000C755F1 /* OktaLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLogger.swift; sourceTree = "<group>"; };
@@ -124,6 +124,9 @@
 		D5C824E42469DBF1005CF747 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerConsoleLoggerTests.swift; sourceTree = "<group>"; };
 		DB510C00105E7489E2C16BA3 /* Pods-OktaLoggerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLoggerTests.debug.xcconfig"; path = "Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		DEC5276524DBF9630022B698 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		DEFB59E024EAC76300A1744F /* OktaLoggerCrashlyticsLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerCrashlyticsLogger.swift; sourceTree = "<group>"; };
+		DF75E3D21D2B9A971A2CAEC7 /* libPods-OktaLoggerDemoApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OktaLoggerDemoApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E251E7FB248AD1B400EF466D /* OktaLoggerDemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OktaLoggerDemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E251E7FD248AD1B400EF466D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E251E7FF248AD1B400EF466D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -132,7 +135,6 @@
 		E251E806248AD1B800EF466D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E251E809248AD1B800EF466D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E251E80B248AD1B800EF466D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E845612E0BE69997F307E326 /* Pods-OktaLogger.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLogger.release.xcconfig"; path = "Target Support Files/Pods-OktaLogger/Pods-OktaLogger.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,7 +142,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				80C36E4C4B7E9BADC897EAF4 /* Pods_OktaLogger.framework in Frameworks */,
+				B3E071E3B33C4657A8B4381B /* libPods-OktaLogger.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,7 +151,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D54461C6246A02CF00C755F1 /* OktaLogger.framework in Frameworks */,
-				8F809E70838C921EFE2420C3 /* Pods_OktaLoggerTests.framework in Frameworks */,
+				C4AA0759EDAC342A3B6B6796 /* libPods-OktaLoggerTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,8 +159,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				804F18F424C00B1C00894A52 /* Pods_OktaLoggerDemoApp.framework in Frameworks */,
-				804F18F224C00B1A00894A52 /* OktaLogger.framework in Frameworks */,
+				E3A717E14689E6EB7A6A088B /* libPods-OktaLoggerDemoApp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,9 +177,9 @@
 		9200B49349EABD23B114BB0F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CD1D77AAC14E07DCDBE81568 /* Pods_OktaLogger.framework */,
-				330F4ED2C904A636A557BACB /* Pods_OktaLoggerDemoApp.framework */,
-				0AD139D0E38251CA2C4842F3 /* Pods_OktaLoggerTests.framework */,
+				62BB891524DBDEF8FC8E9711 /* libPods-OktaLogger.a */,
+				DF75E3D21D2B9A971A2CAEC7 /* libPods-OktaLoggerDemoApp.a */,
+				4FFB48B8C0D4F4DD1D258FFD /* libPods-OktaLoggerTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -187,12 +188,14 @@
 			isa = PBXGroup;
 			children = (
 				80DDE79324B972FC00D0E2F3 /* Config.xcconfig */,
+				DEC5276524DBF9630022B698 /* GoogleService-Info.plist */,
 				E251E7F5248AD13D00EF466D /* Example */,
 				D5C824D62469DBF1005CF747 /* OktaLogger */,
 				D5C824E12469DBF1005CF747 /* OktaLoggerTests */,
 				D5C824D52469DBF1005CF747 /* Products */,
 				FF24FFA3DDFB489FAC52ED9D /* Pods */,
 				9200B49349EABD23B114BB0F /* Frameworks */,
+				DEC9C9CB24E57AC800AAFAE0 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -210,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				8004832F24C1F0F0008BFF3A /* FileLoggers */,
+				DEFB59DF24EAC76300A1744F /* CrashlyticsLogger */,
 				806FF25D24B95A3300994D4D /* OktaLoggerFileLogger.swift */,
 				D5C824D72469DBF1005CF747 /* OktaLogger.h */,
 				D5C824D82469DBF1005CF747 /* Info.plist */,
@@ -249,6 +253,22 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
+		DEC9C9CB24E57AC800AAFAE0 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				330F4ED2C904A636A557BACB /* Pods_OktaLoggerDemoApp.framework */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		DEFB59DF24EAC76300A1744F /* CrashlyticsLogger */ = {
+			isa = PBXGroup;
+			children = (
+				DEFB59E024EAC76300A1744F /* OktaLoggerCrashlyticsLogger.swift */,
+			);
+			path = CrashlyticsLogger;
+			sourceTree = "<group>";
+		};
 		E251E7F5248AD13D00EF466D /* Example */ = {
 			isa = PBXGroup;
 			children = (
@@ -279,12 +299,14 @@
 		FF24FFA3DDFB489FAC52ED9D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8F19A5AD43A044835A9DE194 /* Pods-OktaLogger.debug.xcconfig */,
-				E845612E0BE69997F307E326 /* Pods-OktaLogger.release.xcconfig */,
 				DB510C00105E7489E2C16BA3 /* Pods-OktaLoggerTests.debug.xcconfig */,
 				1626D76D3FE5CD1504C6A51A /* Pods-OktaLoggerTests.release.xcconfig */,
 				C58A9E54B6CE1A902894264C /* Pods-OktaLoggerDemoApp.debug.xcconfig */,
 				00EF841BC9AECECB76C176FE /* Pods-OktaLoggerDemoApp.release.xcconfig */,
+				2BE105519632BEE1AAED7056 /* Pods-OktaLogger.debug.xcconfig */,
+				028D1912AB9DB1ABBDD5EC94 /* Pods-OktaLogger.release.xcconfig */,
+				672ADCC5504F41DBB4546AB0 /* Pods-OktaLogger_.debug.xcconfig */,
+				2212750F97DBDF374821CF2C /* Pods-OktaLogger_.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -308,7 +330,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D5C824E82469DBF1005CF747 /* Build configuration list for PBXNativeTarget "OktaLogger" */;
 			buildPhases = (
-				63CD03A7FFEACD6473EA84BC /* [CP] Check Pods Manifest.lock */,
+				3EDE391A122E4EE902619005 /* [CP] Check Pods Manifest.lock */,
 				D5C824CF2469DBF1005CF747 /* Headers */,
 				D5C824D02469DBF1005CF747 /* Sources */,
 				D5C824D12469DBF1005CF747 /* Frameworks */,
@@ -332,7 +354,6 @@
 				D5C824D92469DBF1005CF747 /* Sources */,
 				D5C824DA2469DBF1005CF747 /* Frameworks */,
 				D5C824DB2469DBF1005CF747 /* Resources */,
-				15B751B1FDDC352E1E2C3531 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -353,12 +374,12 @@
 				E251E7F8248AD1B400EF466D /* Frameworks */,
 				E251E7F9248AD1B400EF466D /* Resources */,
 				80DDE77E24B961B400D0E2F3 /* Embed Frameworks */,
-				F6C3B923028E828C3EF44A03 /* [CP] Embed Pods Frameworks */,
+				DEC5276724DBFE6C0022B698 /* ShellScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				80DDE79024B967DB00D0E2F3 /* PBXTargetDependency */,
+				DE5D6F5824E6D05500AD95FD /* PBXTargetDependency */,
 			);
 			name = OktaLoggerDemoApp;
 			productName = OktaLoggerDemoApp;
@@ -428,6 +449,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E251E80A248AD1B800EF466D /* LaunchScreen.storyboard in Resources */,
+				DEC5276624DBF9630022B698 /* GoogleService-Info.plist in Resources */,
 				E251E807248AD1B800EF466D /* Assets.xcassets in Resources */,
 				E251E805248AD1B400EF466D /* Main.storyboard in Resources */,
 			);
@@ -458,24 +480,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		15B751B1FDDC352E1E2C3531 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		63CD03A7FFEACD6473EA84BC /* [CP] Check Pods Manifest.lock */ = {
+		3EDE391A122E4EE902619005 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -519,22 +524,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F6C3B923028E828C3EF44A03 /* [CP] Embed Pods Frameworks */ = {
+		DEC5276724DBFE6C0022B698 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+			);
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -545,6 +551,7 @@
 			files = (
 				D5B22D06246B602B007ECC2F /* OktaLoggerConsoleLogger.swift in Sources */,
 				D54461C12469FFBA00C755F1 /* OktaLoggerLogLevel.swift in Sources */,
+				DEFB59E124EAC76400A1744F /* OktaLoggerCrashlyticsLogger.swift in Sources */,
 				D54461C3246A023000C755F1 /* OktaLogger.swift in Sources */,
 				D54461CB246B55A600C755F1 /* OktaLoggerDestination.swift in Sources */,
 				8004832E24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift in Sources */,
@@ -586,15 +593,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		80DDE79024B967DB00D0E2F3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D5C824D32469DBF1005CF747 /* OktaLogger */;
-			targetProxy = 80DDE78F24B967DB00D0E2F3 /* PBXContainerItemProxy */;
-		};
 		D54461C5246A02C800C755F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D5C824D32469DBF1005CF747 /* OktaLogger */;
 			targetProxy = D54461C4246A02C800C755F1 /* PBXContainerItemProxy */;
+		};
+		DE5D6F5824E6D05500AD95FD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D5C824D32469DBF1005CF747 /* OktaLogger */;
+			targetProxy = DE5D6F5724E6D05500AD95FD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -744,7 +751,7 @@
 		};
 		D5C824E92469DBF1005CF747 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8F19A5AD43A044835A9DE194 /* Pods-OktaLogger.debug.xcconfig */;
+			baseConfigurationReference = 2BE105519632BEE1AAED7056 /* Pods-OktaLogger.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -775,7 +782,7 @@
 		};
 		D5C824EA2469DBF1005CF747 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E845612E0BE69997F307E326 /* Pods-OktaLogger.release.xcconfig */;
+			baseConfigurationReference = 028D1912AB9DB1ABBDD5EC94 /* Pods-OktaLogger.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";

--- a/OktaLogger/OktaLoggerDestination.swift
+++ b/OktaLogger/OktaLoggerDestination.swift
@@ -18,7 +18,7 @@ public protocol OktaLoggerDestinationProtocol {
     var level: OktaLoggerLogLevel { get set }
 
     /**
-     Logging level for this destination
+     Default event properties
      */
     var defaultProperties: [AnyHashable: Any]? { get }
 

--- a/OktaLoggerTests/Helpers/MockLoggerDestination.h
+++ b/OktaLoggerTests/Helpers/MockLoggerDestination.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <OktaLogger/OktaLogger.h>
+@import OktaLogger;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Podfile
+++ b/Podfile
@@ -1,14 +1,16 @@
 platform :ios, '11.0'
+use_modular_headers!
 
 target 'OktaLogger' do
-    use_frameworks!
-    podspec :name => 'OktaLogger'
+    pod 'Firebase/Crashlytics', '~>6.29.0'
+    pod 'CocoaLumberjack/Swift', '~>3.6.0'
 end
 
 target 'OktaLoggerDemoApp' do
-    use_frameworks!
-end
+    pod 'OktaLogger', :path => '.'
+    pod 'Firebase/Crashlytics', '~>6.29.0'
 
-target 'OktaLoggerTests' do
-    use_frameworks!
+    target 'OktaLoggerTests' do
+      inherit! :search_paths
+    end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,22 +1,103 @@
 PODS:
-  - CocoaLumberjack/Core (3.6.1)
-  - CocoaLumberjack/Swift (3.6.1):
+  - CocoaLumberjack/Core (3.6.2)
+  - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
+  - Firebase/CoreOnly (6.29.0):
+    - FirebaseCore (= 6.9.2)
+  - Firebase/Crashlytics (6.29.0):
+    - Firebase/CoreOnly
+    - FirebaseCrashlytics (~> 4.3.1)
+  - FirebaseCore (6.9.2):
+    - FirebaseCoreDiagnostics (~> 1.3)
+    - GoogleUtilities/Environment (~> 6.7)
+    - GoogleUtilities/Logger (~> 6.7)
+  - FirebaseCoreDiagnostics (1.5.0):
+    - GoogleDataTransport (~> 7.0)
+    - GoogleUtilities/Environment (~> 6.7)
+    - GoogleUtilities/Logger (~> 6.7)
+    - nanopb (~> 1.30905.0)
+  - FirebaseCrashlytics (4.3.1):
+    - FirebaseCore (~> 6.8)
+    - FirebaseInstallations (~> 1.1)
+    - GoogleDataTransport (~> 7.0)
+    - nanopb (~> 1.30905.0)
+    - PromisesObjC (~> 1.2)
+  - FirebaseInstallations (1.5.0):
+    - FirebaseCore (~> 6.8)
+    - GoogleUtilities/Environment (~> 6.7)
+    - GoogleUtilities/UserDefaults (~> 6.7)
+    - PromisesObjC (~> 1.2)
+  - GoogleDataTransport (7.1.0):
+    - nanopb (~> 1.30905.0)
+  - GoogleUtilities/Environment (6.7.1):
+    - PromisesObjC (~> 1.2)
+  - GoogleUtilities/Logger (6.7.1):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/UserDefaults (6.7.1):
+    - GoogleUtilities/Logger
+  - nanopb (1.30905.0):
+    - nanopb/decode (= 1.30905.0)
+    - nanopb/encode (= 1.30905.0)
+  - nanopb/decode (1.30905.0)
+  - nanopb/encode (1.30905.0)
+  - OktaLogger (1.0.3):
+    - OktaLogger/Complete (= 1.0.3)
+    - SwiftLint
+  - OktaLogger/Complete (1.0.3):
+    - OktaLogger/Core
+    - OktaLogger/FirebaseCrashlytics
+    - OktaLogger/Lumberjack
+    - SwiftLint
+  - OktaLogger/Core (1.0.3):
+    - SwiftLint
+  - OktaLogger/FirebaseCrashlytics (1.0.3):
+    - Firebase/Crashlytics (~> 6.29.0)
+    - OktaLogger/Core
+    - SwiftLint
+  - OktaLogger/Lumberjack (1.0.3):
+    - CocoaLumberjack/Swift (~> 3.6.0)
+    - OktaLogger/Core
+    - SwiftLint
+  - PromisesObjC (1.2.9)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
   - CocoaLumberjack/Swift (~> 3.6.0)
-  - SwiftLint
+  - Firebase/Crashlytics (~> 6.29.0)
+  - OktaLogger (from `.`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - CocoaLumberjack
+    - Firebase
+    - FirebaseCore
+    - FirebaseCoreDiagnostics
+    - FirebaseCrashlytics
+    - FirebaseInstallations
+    - GoogleDataTransport
+    - GoogleUtilities
+    - nanopb
+    - PromisesObjC
     - SwiftLint
 
+EXTERNAL SOURCES:
+  OktaLogger:
+    :path: "."
+
 SPEC CHECKSUMS:
-  CocoaLumberjack: b17ae15142558d08bbacf69775fa10c4abbebcc9
+  CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
+  Firebase: 57957c8d6eb3d8b80a560b1dc58be24724b89ff2
+  FirebaseCore: 7930a1946517d94256d857f97371ed993b55f7bd
+  FirebaseCoreDiagnostics: 7535fe695737f8c5b350584292a70b7f8ff0357b
+  FirebaseCrashlytics: 863c851b034baeb3116cd2c91743e37de2dcedfc
+  FirebaseInstallations: 3c520c951305cbf9ca54eb891ff9e6d1fd384881
+  GoogleDataTransport: af0c79193dc59acd37630b4833d0dc6912ae6bd5
+  GoogleUtilities: e121a3867449ce16b0e35ddf1797ea7a389ffdf2
+  nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
+  OktaLogger: 07aafe21e06022f6910b644aeac0b1b8fd0b6a1b
+  PromisesObjC: b48e0338dbbac2207e611750777895f7a5811b75
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
-PODFILE CHECKSUM: 014074e5ed330283e2a724371142593dd1c928b3
+PODFILE CHECKSUM: 701ae7816dd8304d8bbd4ab4f2de0256a59f3d43
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
#### Description

- Add Firebase Crashlytics logger;
- Logs with `error` and `warning` levels reports as non-fatal errors;
- Logs with `info`, `debug`, `uiEvent`, `error` and `warning` levels reports as additional logs for crashes and non-fatal errors;
- Add crash button to example app for fatal error reporting demo.

**Current setup of Firebase Crashlytics SDK has a few restrictions:**
1. I haven't found a way to send fatal exceptions manually, so `error` or `warning` level messages would be reported as non-fatal.
2. We can save up to 8 non-fatal messages per user session, [older unsent messages would be deleted](https://firebase.google.com/docs/crashlytics/customize-crash-reports#log-excepts). By default, firebase sends these messages the next time app launches.
3. Firebase groups non-fatal errors by domain and error code. Since we don't have any specific parameters for errors, the event name has been used to build an error domain.
4. Normal logs (`info`, `debug`, and `uiEvent`) would be sent only with fatal or non-fatal error, and could be accessed in the 'Logs' tab of the error page in the Firebase console. The amount of normal logs is (limited to 64KB per session)[https://firebase.google.com/docs/crashlytics/customize-crash-reports#add-logs].

#### Resolves

[OKTA-318468](https://oktainc.atlassian.net/browse/OKTA-318468)

#### Reviewers

@lihaoli-okta 
@stevelind-okta 
@umangshah-okta 
@okta/ios 