### PR TITLE
Add NSError objects logging method.

### DIFF
--- a/Example/Example-iOS/ViewController.swift
+++ b/Example/Example-iOS/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import OktaLogger
 
 class ViewController: UITableViewController {
-    private let consoleLogCellTexts = ["Log debug message", "Log info message", "Log warning message", "Log UI event message", "Log error message"]
+    private let consoleLogCellTexts = ["Log debug message", "Log info message", "Log warning message", "Log UI event message", "Log error message", "Log NSError object"]
     private let logEventNames = ["test-debug", "test-info", "test-warning", "test-ui", "test-error"]
     private let logLevelCellTexts = ["off", "debug", "info", "warning", "uiEvent", "error", "all"]
     private let logLevels: [OktaLoggerLogLevel] = [.off, .debug, .info, .warning, .uiEvent, .error, .all]
@@ -80,6 +80,9 @@ class ViewController: UITableViewController {
                 OktaLogger.main?.uiEvent(eventName: logEventNames[indexPath.row], message: consoleLogCellTexts[indexPath.row])
             case 4:
                 OktaLogger.main?.error(eventName: logEventNames[indexPath.row], message: consoleLogCellTexts[indexPath.row])
+            case 5:
+                let error = NSError(domain: "com.okta.OktaLoggerDemoApp.test", code: -1, userInfo: ["testData": "some value"])
+                OktaLogger.main?.log(error: error)
             default:
                 break
             }

--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.0.5"
+  s.version          = "1.0.6"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"

--- a/OktaLogger/CrashlyticsLogger/OktaLoggerCrashlyticsLogger.swift
+++ b/OktaLogger/CrashlyticsLogger/OktaLoggerCrashlyticsLogger.swift
@@ -63,6 +63,15 @@ open class OktaLoggerCrashlyticsLogger: OktaLoggerDestinationBase {
         )
     }
 
+    override open func log(error: NSError, file: String, line: NSNumber, funcName: String) {
+        var extendedUserInfo = error.userInfo
+        extendedUserInfo["file"] = file
+        extendedUserInfo["line"] = line
+        extendedUserInfo["funcName"] = funcName
+        let extendedError = NSError(domain: error.domain, code: error.code, userInfo: extendedUserInfo)
+        crashlytics.record(error: extendedError)
+    }
+
     // MARK: - Private
 
     private func buildDomain(with eventName: String) -> String {

--- a/OktaLogger/OktaLogger+Helpers.h
+++ b/OktaLogger/OktaLogger+Helpers.h
@@ -8,3 +8,4 @@
 
 #define okl_error(event, fmt_string, ... ) [OktaLogger.main errorWithEventName:event message:[NSString stringWithFormat:(fmt_string), ##__VA_ARGS__] properties:nil file:[NSString stringWithUTF8String:__FILE__] line:@(__LINE__) funcName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];
 
+#define okl_nserror(error) [OktaLogger.main logWithError:error file:[NSString stringWithUTF8String:__FILE__] line:@(__LINE__) funcName:[NSString stringWithUTF8String:__PRETTY_FUNCTION__]];

--- a/OktaLogger/OktaLoggerDestination.swift
+++ b/OktaLogger/OktaLoggerDestination.swift
@@ -38,6 +38,14 @@ public protocol OktaLoggerDestinationProtocol {
              file: String,
              line: NSNumber,
              funcName: String)
+
+    /**
+     Log NSError object.
+
+     - Parameters
+        - error: NSError object to log.
+     */
+    func log(error: NSError, file: String, line: NSNumber, funcName: String)
 }
 
 /**
@@ -80,8 +88,19 @@ open class OktaLoggerDestinationBase: NSObject, OktaLoggerDestinationProtocol {
         return false
     }
 
-    open func purgeLogs() {
+    open func purgeLogs() {}
 
+    /**
+     This method can be overridden by subclass.
+     Default implementation will call log(level:) function with `error` level
+     and pass `error.domain` and `error.code` as `eventName` parameter,
+     `error.localizedDescription` as `message` and `error.userInfo` as `properties`.
+     */
+    open func log(error: NSError, file: String = #file, line: NSNumber = #line, funcName: String = #function) {
+        let eventName = "\(error.domain), \(error.code)"
+        let message = error.localizedDescription
+        let properties = error.userInfo
+        log(level: .error, eventName: eventName, message: message, properties: properties, file: file, line: line, funcName: funcName)
     }
 
     /**


### PR DESCRIPTION
#### Description

There is a common situation when we need to log an `NSError` object in the client app. Currently we need to convert this object to `OktaLogger.error()` method params or create wrapper to avoid code duplication. Also, we can't fully support `FirebaseCrashlytics` error tracking because it requires error domain and code for grouping events.

To solve this issue a new method has been added for logging `NSError` objects.  
`log(error: NSError, file: String, line: NSNumber, funcName: String)`

By default it will call `OktaLogger.error()` method and pass `error.domain` and `error.code` to eventName parameter, `error.localizedDescription` to message parameter, and `error.userInfo` to properties. This implementation could be overridden by destination objects.

Usage:  
`okl_nserror(error)`  
or  
`OktaLogger.main.log(error)`

#### JIRA

[OKTA-326362](https://oktainc.atlassian.net/browse/OKTA-326362)

#### Reviewers

@lihaoli-okta 
@umangshah-okta 
@IldarAbdullin-okta 
@okta/ios 