### PR TITLE
Add more settings to file logger config.

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.0.6"
+  s.version          = "1.0.7"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"

--- a/OktaLogger/FileLoggers/LumberjackLoggerDelegate.swift
+++ b/OktaLogger/FileLoggers/LumberjackLoggerDelegate.swift
@@ -6,18 +6,25 @@
 import CocoaLumberjack
 
 class LumberjackLoggerDelegate: FileLoggerDelegate {
-    var fileLogger: DDFileLogger = DDFileLogger()
+    var fileLogger: DDFileLogger
     var isLoggingActive = true
 
     /**
      Configure Logger Parameters
      */
     public init(_ logConfig: OktaLoggerFileLoggerConfig) {
-        self.fileLogger.logFileManager.maximumNumberOfLogFiles = 1
-        self.fileLogger.rollingFrequency = logConfig.rollingFrequency
-        DDLog.add(self.fileLogger)
-        self.isLoggingActive = true
-        fileLogger.doNotReuseLogFiles = true
+        fileLogger = {
+            guard let logFolder = logConfig.logFolder else {
+                return DDFileLogger()
+            }
+            let logFileManager = DDLogFileManagerDefault(logsDirectory: logFolder)
+            return DDFileLogger(logFileManager: logFileManager)
+        }()
+        fileLogger.rollingFrequency = logConfig.rollingFrequency
+        fileLogger.doNotReuseLogFiles = !logConfig.reuseLogFiles
+        fileLogger.logFileManager.maximumNumberOfLogFiles = logConfig.maximumNumberOfLogFiles
+        DDLog.add(fileLogger)
+        isLoggingActive = true
     }
 
     /**

--- a/OktaLogger/FileLoggers/OktaLoggerFileLogger.swift
+++ b/OktaLogger/FileLoggers/OktaLoggerFileLogger.swift
@@ -18,13 +18,11 @@ public class OktaLoggerFileLogger: OktaLoggerDestinationBase {
     public init(logConfig: OktaLoggerFileLoggerConfig, identifier: String, level: OktaLoggerLogLevel, defaultProperties: [AnyHashable: Any]?) {
         delegate = LumberjackLoggerDelegate(logConfig)
         super.init(identifier: identifier, level: level, defaultProperties: defaultProperties)
-        let logConfig = OktaLoggerFileLoggerConfig(rollingFrequency: logConfig.rollingFrequency)
     }
 
     @objc
     override public convenience init(identifier: String, level: OktaLoggerLogLevel, defaultProperties: [AnyHashable: Any]?) {
-        let logConfig = OktaLoggerFileLoggerConfig(rollingFrequency: 60 * 60 * 48)
-        self.init(logConfig: logConfig, identifier: identifier, level: level, defaultProperties: defaultProperties)
+        self.init(logConfig: OktaLoggerFileLoggerConfig(), identifier: identifier, level: level, defaultProperties: defaultProperties)
     }
 
     // MARK: Logging

--- a/OktaLogger/FileLoggers/OktaLoggerFileLoggerConfig.swift
+++ b/OktaLogger/FileLoggers/OktaLoggerFileLoggerConfig.swift
@@ -15,7 +15,7 @@ public class OktaLoggerFileLoggerConfig: NSObject {
     }
 
     /**
-    File logging library to use
+    File logging library to use.
     */
     var engine = Engine.CocoaLumberjack
 
@@ -25,20 +25,26 @@ public class OktaLoggerFileLoggerConfig: NSObject {
      How often to roll the log file.
      The frequency is given as an `NSTimeInterval`, which is a double that specifies the interval in seconds.
      Once the log file gets to be this old, it is rolled.
+     Default value is 2 days.
      */
-    var rollingFrequency: TimeInterval
+    public var rollingFrequency: TimeInterval = 48 * 60 * 60
 
     /**
-     Log Folder
+     Custom path to log folder.
+     Default value is `nil` (file logger default folder will be used).
      */
-    var logFolder: String = ""
+    public var logFolder: String?
 
-    public init(rollingFrequency: TimeInterval) {
-        self.rollingFrequency = rollingFrequency
-    }
+    /**
+     If set, file logger will reuse existing log file.
+     If not - it will create new file for every session.
+     Default value is `false`.
+     */
+    public var reuseLogFiles: Bool = false
 
-    public convenience init(rollingFrequency: TimeInterval, logFolder: String) {
-        self.init(rollingFrequency: rollingFrequency)
-        self.logFolder = logFolder
-    }
+    /**
+     Maximum number of log files that could be saved on disk.
+     Default value is `1`.
+     */
+    public var maximumNumberOfLogFiles: UInt = 1
 }

--- a/OktaLoggerTests/OktaLoggerFileLoggerTests.swift
+++ b/OktaLoggerTests/OktaLoggerFileLoggerTests.swift
@@ -38,7 +38,8 @@ class OktaLoggerFileLoggerTests: XCTestCase {
 
     func testLumberjackFileLogger() {
 
-        let logConfig = OktaLoggerFileLoggerConfig(rollingFrequency: TWO_DAYS)
+        let logConfig = OktaLoggerFileLoggerConfig()
+        logConfig.rollingFrequency = TWO_DAYS
         let testObject = LumberjackLoggerDelegate(logConfig)
 
         // default rolling frequency


### PR DESCRIPTION
#### Description

To integrate OktaLogger into SSO extension we need more settings for `FileLogger`:

- `logFolder` (add support in LumberjackLoggerDelegate);
- `reuseLogFiles`;
- `maximumNumberOfLogFiles`;

#### Resolves

[OKTA-334989](https://oktainc.atlassian.net/browse/OKTA-334989)

#### Reviewers

@kaushikkrishnakumar-okta 
@lihaoli-okta 
@okta/ios 