### PR TITLE
Fix defaultProperties description format.

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.0.10"
+  s.version          = "1.0.11"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"

--- a/OktaLogger/OktaLoggerDestination.swift
+++ b/OktaLogger/OktaLoggerDestination.swift
@@ -76,6 +76,7 @@ open class OktaLoggerDestinationBase: NSObject, OktaLoggerDestinationProtocol {
         self.identifier = identifier
         self._level = level
         self._defaultProperties = defaultProperties ?? [AnyHashable: Any]()
+        self.defaultPropertiesDescription = Self.description(of: self._defaultProperties)
     }
 
     public var defaultProperties: [AnyHashable: Any] {
@@ -88,6 +89,7 @@ open class OktaLoggerDestinationBase: NSObject, OktaLoggerDestinationProtocol {
             self.lock.writeLock()
             defer { self.lock.unlock() }
             self._defaultProperties = value
+            self.defaultPropertiesDescription = Self.description(of: self._defaultProperties)
         }
     }
 
@@ -137,7 +139,7 @@ open class OktaLoggerDestinationBase: NSObject, OktaLoggerDestinationProtocol {
     open func stringValue(level: OktaLoggerLogLevel, eventName: String, message: String?, file: String, line: NSNumber, funcName: String) -> String {
         let filename = file.split(separator: "/").last
         let logMessageIcon = OktaLoggerLogLevel.logMessageIcon(level: level)
-        return "{\(logMessageIcon) \"\(eventName)\": {\"message\": \"\(message ?? "")\", \"defaultProperties\": \"\(defaultProperties.description)\", \"location\": \"\(filename ?? ""):\(funcName):\(line)\"}}"
+        return "{\(logMessageIcon) \"\(eventName)\": {\"message\": \"\(message ?? "")\", \"defaultProperties\": \"\(defaultPropertiesDescription)\", \"location\": \"\(filename ?? ""):\(funcName):\(line)\"}}"
     }
 
     open func addDefaultProperties(_ defaultProperties: [AnyHashable: Any]) {
@@ -154,4 +156,13 @@ open class OktaLoggerDestinationBase: NSObject, OktaLoggerDestinationProtocol {
     private var lock = ReadWriteLock()
     private var _level: OktaLoggerLogLevel
     private var _defaultProperties: [AnyHashable: Any]
+    private var defaultPropertiesDescription: String
+
+    private static func description(of dictionary: [AnyHashable: Any]) -> String {
+        return dictionary
+            .map { (key: String(describing: $0.key), value: $0.value) }
+            .sorted(by: { $0.key < $1.key })
+            .map { "\($0.key): \($0.value)" }
+            .joined(separator: "; ")
+    }
 }

--- a/OktaLoggerTests/Helpers/MockLoggerDestination.swift
+++ b/OktaLoggerTests/Helpers/MockLoggerDestination.swift
@@ -28,12 +28,14 @@ class MockLogEvent: NSObject {
 @objc
 class MockLoggerDestination: OktaLoggerDestinationBase {
     var events = [MockLogEvent]()
+    var eventMessages = [String]()
     let serialQueue = DispatchQueue(label: UUID().uuidString)
 
     override public func log(level: OktaLoggerLogLevel, eventName: String, message: String?, properties: [AnyHashable: Any]?, file: String, line: NSNumber, funcName: String) {
         let event = MockLogEvent(name: eventName, message: message, properties: properties, file: file, line: line, funcName: funcName)
         serialQueue.sync {
             self.events.append(event)
+            self.eventMessages.append(stringValue(level: level, eventName: eventName, message: message, file: file, line: line, funcName: funcName))
         }
     }
 }

--- a/OktaLoggerTests/OktaLoggerTests.swift
+++ b/OktaLoggerTests/OktaLoggerTests.swift
@@ -72,6 +72,53 @@ class OktaLoggerTests: XCTestCase {
     }
 
     /**
+     Verify that default properties have the correct format and order in the log message.
+     */
+    func testDefaultPropertiesMessage() {
+        let properties = ["A": "value 1", "B": "value 2", "C": "value 3"]
+        let expectedMessage = "A: value 1; B: value 2; C: value 3"
+        let destination = MockLoggerDestination(identifier: "test", level: .all, defaultProperties: properties)
+        let logger = OktaLogger(destinations: [destination])
+
+        for _ in 0..<20 {
+            logger.info(eventName: "hello", message: "world", properties: nil)
+        }
+
+        XCTAssertEqual(destination.eventMessages.count, 20)
+        destination.eventMessages.forEach {
+            XCTAssertTrue($0.contains(expectedMessage))
+        }
+    }
+
+    /**
+     Verify that log message is correct after updating default properties.
+     */
+    func testDefaultPropertiesChange() {
+        let properties = ["A": "value 1", "B": "value 2"]
+        let destination = MockLoggerDestination(identifier: "test", level: .all, defaultProperties: properties)
+        let logger = OktaLogger(destinations: [destination])
+
+        logger.info(eventName: "hello", message: "world", properties: nil)
+        XCTAssertEqual(destination.eventMessages.count, 1)
+        XCTAssertTrue(destination.eventMessages[0].contains("\"A: value 1; B: value 2\""))
+
+        destination.addDefaultProperties(["B": "value 3", "C": "value 4"])
+        logger.info(eventName: "hello", message: "world", properties: nil)
+        XCTAssertEqual(destination.eventMessages.count, 2)
+        XCTAssertTrue(destination.eventMessages[1].contains("\"A: value 1; B: value 3; C: value 4\""))
+
+        destination.removeDefaultProperties(for: "B")
+        logger.info(eventName: "hello", message: "world", properties: nil)
+        XCTAssertEqual(destination.eventMessages.count, 3)
+        XCTAssertTrue(destination.eventMessages[2].contains("\"A: value 1; C: value 4\""))
+
+        destination.defaultProperties = ["D": "value 5", "E": "value 6"]
+        logger.info(eventName: "hello", message: "world", properties: nil)
+        XCTAssertEqual(destination.eventMessages.count, 4)
+        XCTAssertTrue(destination.eventMessages[3].contains("\"D: value 5; E: value 6\""))
+    }
+
+    /**
      Verify that the logging level is honored when logging
      */
     func testLoggingLevels() {


### PR DESCRIPTION
#### Description

- Remove `AnyHashable()` strings from the default properties description;
- Sort default properties by key, so we have same properties order in every message.

#### Related ticket

[OKTA-334820](https://oktainc.atlassian.net/browse/OKTA-334820)

#### Reviewers

@lihaoli-okta @stevelind-okta @AntonVoitsekhivskyi-okta 