### PR TITLE
Av bump crashlytics

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.0.11"
+  s.version          = "1.0.12"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
     crashlytics.source_files = [
       'OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift'
     ]
-    crashlytics.dependency 'Firebase/Crashlytics', '~>6.29.0'
+    crashlytics.dependency 'Firebase/Crashlytics', '~>7.4.0'
     crashlytics.dependency 'OktaLogger/Core'
   end
 

--- a/Podfile
+++ b/Podfile
@@ -2,13 +2,13 @@ platform :ios, '11.0'
 use_modular_headers!
 
 target 'OktaLogger' do
-    pod 'Firebase/Crashlytics', '~>6.29.0'
+    pod 'Firebase/Crashlytics', '~>7.4.0'
     pod 'CocoaLumberjack/Swift', '~>3.6.0'
 end
 
 target 'OktaLoggerDemoApp' do
     pod 'OktaLogger', :path => '.'
-    pod 'Firebase/Crashlytics', '~>6.29.0'
+    pod 'Firebase/Crashlytics', '~>7.4.0'
 
     target 'OktaLoggerTests' do
       inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,72 +2,74 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - Firebase/CoreOnly (6.29.0):
-    - FirebaseCore (= 6.9.2)
-  - Firebase/Crashlytics (6.29.0):
+  - Firebase/CoreOnly (7.4.0):
+    - FirebaseCore (= 7.4.0)
+  - Firebase/Crashlytics (7.4.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 4.3.1)
-  - FirebaseCore (6.9.2):
-    - FirebaseCoreDiagnostics (~> 1.3)
-    - GoogleUtilities/Environment (~> 6.7)
-    - GoogleUtilities/Logger (~> 6.7)
-  - FirebaseCoreDiagnostics (1.5.0):
-    - GoogleDataTransport (~> 7.0)
-    - GoogleUtilities/Environment (~> 6.7)
-    - GoogleUtilities/Logger (~> 6.7)
-    - nanopb (~> 1.30905.0)
-  - FirebaseCrashlytics (4.3.1):
-    - FirebaseCore (~> 6.8)
-    - FirebaseInstallations (~> 1.1)
-    - GoogleDataTransport (~> 7.0)
-    - nanopb (~> 1.30905.0)
+    - FirebaseCrashlytics (~> 7.4.0)
+  - FirebaseCore (7.4.0):
+    - FirebaseCoreDiagnostics (~> 7.4)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Logger (~> 7.0)
+  - FirebaseCoreDiagnostics (7.5.0):
+    - GoogleDataTransport (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Logger (~> 7.0)
+    - nanopb (~> 2.30907.0)
+  - FirebaseCrashlytics (7.4.0):
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleDataTransport (~> 8.0)
+    - nanopb (~> 2.30907.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstallations (1.5.0):
-    - FirebaseCore (~> 6.8)
-    - GoogleUtilities/Environment (~> 6.7)
-    - GoogleUtilities/UserDefaults (~> 6.7)
+  - FirebaseInstallations (7.5.0):
+    - FirebaseCore (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - GoogleDataTransport (7.1.0):
-    - nanopb (~> 1.30905.0)
-  - GoogleUtilities/Environment (6.7.1):
+  - GoogleDataTransport (8.2.0):
+    - nanopb (~> 2.30907.0)
+  - GoogleUtilities/Environment (7.2.2):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.7.1):
+  - GoogleUtilities/Logger (7.2.2):
     - GoogleUtilities/Environment
-  - GoogleUtilities/UserDefaults (6.7.1):
+  - GoogleUtilities/UserDefaults (7.2.2):
     - GoogleUtilities/Logger
-  - nanopb (1.30905.0):
-    - nanopb/decode (= 1.30905.0)
-    - nanopb/encode (= 1.30905.0)
-  - nanopb/decode (1.30905.0)
-  - nanopb/encode (1.30905.0)
-  - OktaLogger (1.0.10):
-    - OktaLogger/Complete (= 1.0.10)
+  - nanopb (2.30907.0):
+    - nanopb/decode (= 2.30907.0)
+    - nanopb/encode (= 2.30907.0)
+  - nanopb/decode (2.30907.0)
+  - nanopb/encode (2.30907.0)
+  - OktaLogger (1.0.11):
+    - OktaLogger/Complete (= 1.0.11)
     - SwiftLint
-  - OktaLogger/Complete (1.0.10):
+  - OktaLogger/Complete (1.0.11):
     - OktaLogger/FileLogger
     - OktaLogger/FirebaseCrashlytics
     - SwiftLint
-  - OktaLogger/Core (1.0.10):
+  - OktaLogger/Core (1.0.11):
     - SwiftLint
-  - OktaLogger/FileLogger (1.0.10):
+  - OktaLogger/FileLogger (1.0.11):
     - CocoaLumberjack/Swift (~> 3.6.0)
     - OktaLogger/Core
     - SwiftLint
-  - OktaLogger/FirebaseCrashlytics (1.0.10):
-    - Firebase/Crashlytics (~> 6.29.0)
+  - OktaLogger/FirebaseCrashlytics (1.0.11):
+    - Firebase/Crashlytics (~> 7.4.0)
     - OktaLogger/Core
     - SwiftLint
-  - PromisesObjC (1.2.9)
+  - PromisesObjC (1.2.12)
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
   - CocoaLumberjack/Swift (~> 3.6.0)
-  - Firebase/Crashlytics (~> 6.29.0)
+  - Firebase/Crashlytics (~> 7.4.0)
   - OktaLogger (from `.`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - CocoaLumberjack
+    - SwiftLint
+  trunk:
     - Firebase
     - FirebaseCore
     - FirebaseCoreDiagnostics
@@ -77,7 +79,6 @@ SPEC REPOS:
     - GoogleUtilities
     - nanopb
     - PromisesObjC
-    - SwiftLint
 
 EXTERNAL SOURCES:
   OktaLogger:
@@ -85,18 +86,18 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  Firebase: 57957c8d6eb3d8b80a560b1dc58be24724b89ff2
-  FirebaseCore: 7930a1946517d94256d857f97371ed993b55f7bd
-  FirebaseCoreDiagnostics: 7535fe695737f8c5b350584292a70b7f8ff0357b
-  FirebaseCrashlytics: 863c851b034baeb3116cd2c91743e37de2dcedfc
-  FirebaseInstallations: 3c520c951305cbf9ca54eb891ff9e6d1fd384881
-  GoogleDataTransport: af0c79193dc59acd37630b4833d0dc6912ae6bd5
-  GoogleUtilities: e121a3867449ce16b0e35ddf1797ea7a389ffdf2
-  nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
-  OktaLogger: a691b5879b20bd5d3dd809224d774b0186e833a1
-  PromisesObjC: b48e0338dbbac2207e611750777895f7a5811b75
+  Firebase: 09fb40287b6dfc8ee65f726fa0b788719d3f2a07
+  FirebaseCore: 99c06e5a1e8d6952e75cb1f0a6d0b23c0f5ccdcf
+  FirebaseCoreDiagnostics: 35685db68b11fe7d19d2d8b557fd7e3a56ac81cc
+  FirebaseCrashlytics: ef6b0947ab6819b5cb335f8c0a7677cd57d544c5
+  FirebaseInstallations: a46ae59915f0931e18814164849cd0354bea24ed
+  GoogleDataTransport: 1024b1a4dfbd7a0e92cb20d7e0a6f1fb66b449a4
+  GoogleUtilities: 31c5b01f978a70c6cff2afc6272b3f1921614b43
+  nanopb: 59221d7f958fb711001e6a449489542d92ae113e
+  OktaLogger: ecac8b1a436f0f8f91280d2154510cfc1697951d
+  PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
-PODFILE CHECKSUM: 701ae7816dd8304d8bbd4ab4f2de0256a59f3d43
+PODFILE CHECKSUM: 56d87b5cb773d85ba14abcf465af02c04739eccb
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.10.1


### PR DESCRIPTION
#### Description:
Updates Firebase to v 7.4.0 as well as all the dependent pods, which also are using Firebase.
This is a part of a sequence of PRs to make it happen for OV 
Refer to ASCII with Firebase dependencies graph:


``` 

                                                         ____
Firebase ---> Okta Logger ----------> DevicesSDK -----> |    |
                          \                             |    |
                           \--------------------------> | OV |
Firebase ---> Okta Config ----------------------------> |____|


```


Full set of PRs is:
OV: https://github.com/okta/okta-ios-verify/pull/917 ([Bacon green](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-ios-verify&sha=5588d38ebb3066fcc720d32ea139d9344ae62d82))
DevicesSDK: https://github.com/okta/okta-devices-swift/pull/158 ([Bacon green](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-devices-swift&sha=4d8d7cf6f093c1ac32394a4fbb82996c1fb8bc03)) 
OktaLogger: https://github.com/okta/okta-logger-swift/pull/30 ([Bacon green](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-ios-logger&sha=70265580114b2a2bcb48e0c3005f51cb57ac5486))
OktaConfig: https://github.com/okta/okta-config-swift/pull/13 ([Bacon green](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-config-swift&sha=666a3977d6ade2b5fa865d11e8fdaff072b690cf))