### PR TITLE
Add more mutithreading tests.

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.1.0"
+  s.version          = "1.1.1"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"

--- a/OktaLogger.xcodeproj/project.pbxproj
+++ b/OktaLogger.xcodeproj/project.pbxproj
@@ -30,8 +30,11 @@
 		D5C824E32469DBF1005CF747 /* OktaLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C824E22469DBF1005CF747 /* OktaLoggerTests.swift */; };
 		D5C824E52469DBF1005CF747 /* OktaLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = D5C824D72469DBF1005CF747 /* OktaLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5D0978E246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */; };
+		DE2FFE21260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FFE20260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift */; };
 		DE504DC425BEE84A00B27BDD /* OktaLoggerFileLogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE504DC325BEE84A00B27BDD /* OktaLoggerFileLogFormatter.swift */; };
+		DEABAFC9260C7C0100DB7008 /* FileTestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEABAFC8260C7C0100DB7008 /* FileTestsHelper.swift */; };
 		DEC5276624DBF9630022B698 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DEC5276524DBF9630022B698 /* GoogleService-Info.plist */; };
+		DEF2CC23260A341300F8B644 /* OktaLoggerMultithreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF2CC22260A341300F8B644 /* OktaLoggerMultithreadingTests.swift */; };
 		DEFB59E124EAC76400A1744F /* OktaLoggerFirebaseCrashlyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB59E024EAC76300A1744F /* OktaLoggerFirebaseCrashlyticsLogger.swift */; };
 		E251E7FE248AD1B400EF466D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E7FD248AD1B400EF466D /* AppDelegate.swift */; };
 		E251E800248AD1B400EF466D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E251E7FF248AD1B400EF466D /* SceneDelegate.swift */; };
@@ -122,8 +125,11 @@
 		D5C824E42469DBF1005CF747 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerConsoleLoggerTests.swift; sourceTree = "<group>"; };
 		DB510C00105E7489E2C16BA3 /* Pods-OktaLoggerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLoggerTests.debug.xcconfig"; path = "Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		DE2FFE20260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLoggerMultithreadingTests.swift; sourceTree = "<group>"; };
 		DE504DC325BEE84A00B27BDD /* OktaLoggerFileLogFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLogFormatter.swift; sourceTree = "<group>"; };
+		DEABAFC8260C7C0100DB7008 /* FileTestsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTestsHelper.swift; sourceTree = "<group>"; };
 		DEC5276524DBF9630022B698 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		DEF2CC22260A341300F8B644 /* OktaLoggerMultithreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerMultithreadingTests.swift; sourceTree = "<group>"; };
 		DEFB59E024EAC76300A1744F /* OktaLoggerFirebaseCrashlyticsLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerFirebaseCrashlyticsLogger.swift; sourceTree = "<group>"; };
 		DF75E3D21D2B9A971A2CAEC7 /* libPods-OktaLoggerDemoApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OktaLoggerDemoApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E251E7FB248AD1B400EF466D /* OktaLoggerDemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OktaLoggerDemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -233,12 +239,14 @@
 			isa = PBXGroup;
 			children = (
 				D5C824E22469DBF1005CF747 /* OktaLoggerTests.swift */,
+				DEF2CC22260A341300F8B644 /* OktaLoggerMultithreadingTests.swift */,
+				E2E7C95225196D83006B8DAE /* OktaLoggerDefaultPropertiesTests.swift */,
+				804F18F624C0174800894A52 /* OktaLoggerFileLoggerTests.swift */,
+				DE2FFE20260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift */,
 				D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */,
 				D5D0978A246CB52900C1362F /* Helpers */,
 				D5C824E42469DBF1005CF747 /* Info.plist */,
 				D5B22D07246C8E39007ECC2F /* OktaLoggerTests-Bridging-Header.h */,
-				804F18F624C0174800894A52 /* OktaLoggerFileLoggerTests.swift */,
-				E2E7C95225196D83006B8DAE /* OktaLoggerDefaultPropertiesTests.swift */,
 			);
 			path = OktaLoggerTests;
 			sourceTree = "<group>";
@@ -246,6 +254,7 @@
 		D5D0978A246CB52900C1362F /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				DEABAFC8260C7C0100DB7008 /* FileTestsHelper.swift */,
 				D5B22D0A246CA47E007ECC2F /* MockLoggerDestination.swift */,
 				D55F2C1C246F153200680A96 /* MockLoggerDestination.h */,
 				D55F2C1D246F153200680A96 /* MockLoggerDestination.m */,
@@ -568,8 +577,11 @@
 			files = (
 				804F18F724C0174800894A52 /* OktaLoggerFileLoggerTests.swift in Sources */,
 				D5D0978E246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift in Sources */,
+				DEABAFC9260C7C0100DB7008 /* FileTestsHelper.swift in Sources */,
 				D55F2C1E246F153200680A96 /* MockLoggerDestination.m in Sources */,
+				DE2FFE21260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift in Sources */,
 				D5C824E32469DBF1005CF747 /* OktaLoggerTests.swift in Sources */,
+				DEF2CC23260A341300F8B644 /* OktaLoggerMultithreadingTests.swift in Sources */,
 				D5B22D0B246CA47E007ECC2F /* MockLoggerDestination.swift in Sources */,
 				E2E7C95325196D83006B8DAE /* OktaLoggerDefaultPropertiesTests.swift in Sources */,
 			);

--- a/OktaLoggerTests/Helpers/FileTestsHelper.swift
+++ b/OktaLoggerTests/Helpers/FileTestsHelper.swift
@@ -1,0 +1,57 @@
+//
+//  FileTestsHelper.swift
+//  OktaLoggerTests
+//
+//  Created by Borys Kasianenko on 3/25/21.
+//  Copyright © 2021 Okta, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import OktaLogger
+
+class FileTestsHelper {
+
+    static func countLines(_ data: Data) -> Int {
+        let logData = String(data: data as Data, encoding: .utf8)
+        var lineCount: Int = 0
+        logData?.enumerateLines { (_, _) in
+            lineCount += 1
+        }
+        return lineCount
+    }
+
+    static func getPaths(testObject: LumberjackLoggerDelegate) -> [URL] {
+        let logFileInfos = testObject.fileLogger.logFileManager.sortedLogFileInfos
+        var logFilePathArray = [URL]()
+        for logFileInfo in logFileInfos {
+            if logFileInfo.isArchived {
+                continue
+            }
+            let logFilePath = logFileInfo.filePath
+            let fileURL = URL(fileURLWithPath: logFilePath)
+            if let _ = try? Data(contentsOf: fileURL, options: Data.ReadingOptions.mappedIfSafe) {
+                logFilePathArray.insert(fileURL, at: 0)
+            }
+        }
+        return logFilePathArray
+    }
+
+    static var defaultFileConfig: OktaLoggerFileLoggerConfig {
+        // New random folder is created for each config.
+        // This helps us to avoid collision between different tests.
+        let config = OktaLoggerFileLoggerConfig()
+        config.logFolder = FileTestsHelper.testLogsFolder
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .path
+        return config
+    }
+
+    static func cleanUpLogs() {
+        try? FileManager.default.removeItem(at: FileTestsHelper.testLogsFolder)
+    }
+
+    static private var testLogsFolder: URL {
+        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("TestLogs", isDirectory: true)
+    }
+}

--- a/OktaLoggerTests/OktaLoggerDefaultPropertiesTests.swift
+++ b/OktaLoggerTests/OktaLoggerDefaultPropertiesTests.swift
@@ -146,30 +146,4 @@ class OktaLoggerDefaultPropertiesTests: XCTestCase {
         XCTAssertEqual(dict, consoleLogger.defaultProperties as? [String: String])
         XCTAssertEqual(dict, fileLogger.defaultProperties as? [String: String])
     }
-
-    func testMultithreadingAddDefaultPropertiesAndLogToConsole() {
-        let expectation = XCTestExpectation(description: "all logging complete")
-        let destination = OktaLoggerConsoleLogger(identifier: "com.okta.consoleLogger", level: .all, defaultProperties: nil)
-        let logger = OktaLogger(destinations: [destination])
-
-        var completed = 0
-        let threads = 1000
-        let serialQueue = DispatchQueue(label: "com.okta.serialQueue")
-        let concurrentQueue = DispatchQueue(label: "com.okta.concurrentQueue", qos: .userInteractive, attributes: .concurrent, autoreleaseFrequency: .inherit, target: nil)
-        for i in 0..<threads {
-            concurrentQueue.async {
-                logger.addDefaultProperties(["testKey1": "testValue1"], identifiers: nil)
-                logger.debug(eventName: "\(i)", message: "Thread count: \(i)")
-                logger.removeDefaultProperties(for: "testKey1", identifiers: nil)
-                serialQueue.async {
-                    completed += 1
-                    if completed == threads {
-                        expectation.fulfill()
-                    }
-                }
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 10)
-    }
 }

--- a/OktaLoggerTests/OktaLoggerFileLoggerMultithreadingTests.swift
+++ b/OktaLoggerTests/OktaLoggerFileLoggerMultithreadingTests.swift
@@ -1,0 +1,73 @@
+//
+//  OktaLoggerFileLoggerMultithreadingTests.swift
+//  OktaLoggerTests
+//
+//  Created by Borys Kasianenko on 3/24/21.
+//  Copyright © 2021 Okta, Inc. All rights reserved.
+//
+
+import XCTest
+@testable import OktaLogger
+
+class OktaLoggerFileLoggerMultithreadingTests: XCTestCase {
+
+    private var lumberjackDelegate: LumberjackLoggerDelegate!
+    private let defaultIterationsCount = 100
+    private let defaultTimeout: TimeInterval = 20.0
+
+    override func setUp() {
+        super.setUp()
+        lumberjackDelegate = LumberjackLoggerDelegate(FileTestsHelper.defaultFileConfig)
+    }
+
+    override class func tearDown() {
+        FileTestsHelper.cleanUpLogs()
+    }
+
+    /**
+     Verify that LumberjackLogger delegate can read and write logs simultaneously.
+     */
+    func testLogAndReadMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "All read/write operations finished")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount * 2
+
+        for _ in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.lumberjackDelegate.log(.debug, "Debug message\n")
+                testFinishExpectation.fulfill()
+            }
+            DispatchQueue.global(qos: .default).async {
+                _ = self.lumberjackDelegate.getLogs()
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        let actualLogs = lumberjackDelegate.getLogs()
+        XCTAssertEqual(actualLogs.count, 1)
+        XCTAssertEqual(FileTestsHelper.countLines(actualLogs[0]), defaultIterationsCount)
+    }
+
+    /**
+     Verify that LumberjackLogger delegate can write and purge logs simultaneously.
+     */
+    func testLogAndPurgeMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "All write/purge operations finished")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount * 2
+
+        for _ in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.lumberjackDelegate.log(.debug, "Debug message")
+                testFinishExpectation.fulfill()
+            }
+            DispatchQueue.global(qos: .default).async {
+                self.lumberjackDelegate.purgeLogs()
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        lumberjackDelegate.purgeLogs()
+        XCTAssertTrue(lumberjackDelegate.getLogs().isEmpty)
+    }
+}

--- a/OktaLoggerTests/OktaLoggerFileLoggerTests.swift
+++ b/OktaLoggerTests/OktaLoggerFileLoggerTests.swift
@@ -7,14 +7,21 @@
 //
 
 import XCTest
-
 @testable import OktaLogger
 
 class OktaLoggerFileLoggerTests: XCTestCase {
-    let TWO_DAYS = TimeInterval(48 * 60 * 60)
+
+    override class func tearDown() {
+        FileTestsHelper.cleanUpLogs()
+    }
 
     func testOktaFileLogger() {
-        let testObject: OktaLoggerFileLogger = OktaLoggerFileLogger(identifier: "hello.world", level: .all, defaultProperties: nil)
+        let testObject: OktaLoggerFileLogger = OktaLoggerFileLogger(
+            logConfig: FileTestsHelper.defaultFileConfig,
+            identifier: "hello.world",
+            level: .all,
+            defaultProperties: nil
+        )
         let logger = OktaLogger(destinations: [testObject])
         XCTAssertEqual(testObject.logsCanBePurged(), true)
 
@@ -31,7 +38,7 @@ class OktaLoggerFileLoggerTests: XCTestCase {
             receiveLogsExpectation.fulfill()
         }
         wait(for: [receiveLogsExpectation], timeout: 5.0)
-        XCTAssertEqual(countLines(logs[0]), 5)
+        XCTAssertEqual(FileTestsHelper.countLines(logs[0]), 5)
         testObject.purgeLogs()
 
         // Call log method 2 times
@@ -46,18 +53,16 @@ class OktaLoggerFileLoggerTests: XCTestCase {
             receiveLogsExpectation.fulfill()
         }
         wait(for: [receiveLogsExpectation], timeout: 5.0)
-        XCTAssertEqual(countLines(logs[0]), 2)
+        XCTAssertEqual(FileTestsHelper.countLines(logs[0]), 2)
         testObject.purgeLogs()
     }
 
     func testLumberjackFileLogger() {
-
-        let logConfig = OktaLoggerFileLoggerConfig()
-        logConfig.rollingFrequency = TWO_DAYS
-        let testObject = LumberjackLoggerDelegate(logConfig)
+        let config = FileTestsHelper.defaultFileConfig
+        let testObject = LumberjackLoggerDelegate(config)
 
         // default rolling frequency
-        XCTAssertEqual(testObject.fileLogger.rollingFrequency, TWO_DAYS)
+        XCTAssertEqual(testObject.fileLogger.rollingFrequency, config.rollingFrequency)
         XCTAssertNotNil(testObject.directoryPath())
         XCTAssertEqual(testObject.logsCanBePurged(), true)
 
@@ -74,10 +79,10 @@ class OktaLoggerFileLoggerTests: XCTestCase {
             receiveLogsExpectation.fulfill()
         }
         wait(for: [receiveLogsExpectation], timeout: 5.0)
-        XCTAssertEqual(countLines(logs[0]), 5)
+        XCTAssertEqual(FileTestsHelper.countLines(logs[0]), 5)
 
         // Verify that actual log files paths same as expected
-        var extectedPaths = getPaths(testObject: testObject)
+        var extectedPaths = FileTestsHelper.getPaths(testObject: testObject)
         var actualPaths = testObject.getLogPaths()
         XCTAssertEqual(actualPaths, extectedPaths)
         testObject.purgeLogs()
@@ -90,62 +95,12 @@ class OktaLoggerFileLoggerTests: XCTestCase {
             receiveLogsExpectation.fulfill()
         }
         wait(for: [receiveLogsExpectation], timeout: 5.0)
-        XCTAssertEqual(countLines(logs[0]), 2)
+        XCTAssertEqual(FileTestsHelper.countLines(logs[0]), 2)
 
         // Verify that actual log files paths same as expected
-        extectedPaths = getPaths(testObject: testObject)
+        extectedPaths = FileTestsHelper.getPaths(testObject: testObject)
         actualPaths = testObject.getLogPaths()
         XCTAssertEqual(actualPaths, extectedPaths)
         testObject.purgeLogs()
-    }
-
-    func testReadMultithreading() {
-        let testObject = LumberjackLoggerDelegate(.init())
-        testObject.purgeLogs()
-        let iterationsCount = 100
-
-        let testFinishExpectation = XCTestExpectation(description: "All read/write operations finished")
-        testFinishExpectation.expectedFulfillmentCount = 200
-        for _ in 0..<iterationsCount {
-            DispatchQueue.global(qos: .default).async {
-                testObject.log(.debug, "Debug message")
-                testFinishExpectation.fulfill()
-            }
-            DispatchQueue.global(qos: .default).async {
-                _ = testObject.getLogs()
-                testFinishExpectation.fulfill()
-            }
-        }
-        wait(for: [testFinishExpectation], timeout: 30.0)
-
-        let actualLogs = testObject.getLogs()
-        XCTAssertEqual(actualLogs.count, 1)
-        XCTAssertEqual(countLines(actualLogs[0]), 100)
-        testObject.purgeLogs()
-    }
-
-    func countLines(_ data: Data) -> Int {
-        let logData = String(data: data as Data, encoding: .utf8)
-        var lineCount: Int = 0
-        logData?.enumerateLines { (_, _) in
-            lineCount += 1
-        }
-        return lineCount
-    }
-
-    private func getPaths(testObject: LumberjackLoggerDelegate) -> [URL] {
-        let logFileInfos = testObject.fileLogger.logFileManager.sortedLogFileInfos
-        var logFilePathArray = [URL]()
-        for logFileInfo in logFileInfos {
-            if logFileInfo.isArchived {
-                continue
-            }
-            let logFilePath = logFileInfo.filePath
-            let fileURL = URL(fileURLWithPath: logFilePath)
-            if let _ = try? Data(contentsOf: fileURL, options: Data.ReadingOptions.mappedIfSafe) {
-                logFilePathArray.insert(fileURL, at: 0)
-            }
-        }
-        return logFilePathArray
     }
 }

--- a/OktaLoggerTests/OktaLoggerMultithreadingTests.swift
+++ b/OktaLoggerTests/OktaLoggerMultithreadingTests.swift
@@ -1,0 +1,270 @@
+//
+//  OktaLoggerMultithreadingTests.swift
+//  OktaLoggerTests
+//
+//  Created by Borys Kasianenko on 3/23/2021.
+//  Copyright © 2021 Okta, Inc. All rights reserved.
+//
+
+import XCTest
+@testable import OktaLogger
+
+class OktaLoggerMultithreadingTests: XCTestCase {
+
+    private var oktaLogger: OktaLogger!
+    private let defaultIterationsCount = 100
+    private let defaultTimeout: TimeInterval = 10.0
+
+    override func setUp() {
+        super.setUp()
+        oktaLogger = OktaLogger()
+    }
+
+    // MARK: - Logging tests
+
+    /**
+     Verify that OktaLogger can process log messages from different threads simultaneously.
+     */
+    func testLogEventMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount
+
+        let destination1 = MockLoggerDestination(identifier: "test1", level: .all, defaultProperties: nil)
+        let destination2 = MockLoggerDestination(identifier: "test2", level: .all, defaultProperties: nil)
+        oktaLogger.addDestination(destination1)
+        oktaLogger.addDestination(destination2)
+
+        for _ in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.info(eventName: "Info event", message: nil)
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        XCTAssertEqual(destination1.eventMessages.count, defaultIterationsCount)
+        XCTAssertEqual(destination2.eventMessages.count, defaultIterationsCount)
+    }
+
+    /**
+     Verify that log messages can be processed simultaneously with changing destinations.
+     This test will cause crash if `destinations` property accessed without read lock.
+     */
+    func testLogEventWithMutatingDestinationsMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount * 2
+
+        for index in 0..<defaultIterationsCount {
+            oktaLogger.addDestination(testDestination(identifier: "test\(index)"))
+        }
+
+        for iteration in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.removeDestination(withIdentifier: "test\(iteration)")
+                testFinishExpectation.fulfill()
+            }
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.info(eventName: "Info event", message: nil)
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        XCTAssertTrue(oktaLogger.destinations.isEmpty)
+    }
+
+    /**
+     Verify that OktaLogger can process error messages from different threads simultaneously.
+     */
+    func testLogErrorMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount
+
+        let destination1 = MockLoggerDestination(identifier: "test1", level: .all, defaultProperties: nil)
+        let destination2 = MockLoggerDestination(identifier: "test2", level: .all, defaultProperties: nil)
+        oktaLogger.addDestination(destination1)
+        oktaLogger.addDestination(destination2)
+
+        for _ in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.log(error: NSError(domain: "test", code: 0, userInfo: nil))
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        XCTAssertEqual(destination1.events.count, defaultIterationsCount)
+        XCTAssertEqual(destination2.events.count, defaultIterationsCount)
+    }
+
+    /**
+     Verify that error messages can be processed simultaneously with changing destinations.
+     This test will cause crash if `destinations` property accessed without read lock.
+     */
+    func testLogErrorWithMutatingDestinationsMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount * 2
+
+        for index in 0..<defaultIterationsCount {
+            oktaLogger.addDestination(testDestination(identifier: "test\(index)"))
+        }
+
+        for iteration in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.removeDestination(withIdentifier: "test\(iteration)")
+                testFinishExpectation.fulfill()
+            }
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.log(error: NSError(domain: "test", code: 0, userInfo: nil))
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        XCTAssertTrue(oktaLogger.destinations.isEmpty)
+    }
+
+    // MARK: - Log level modification
+
+    /**
+     Verify that logging level can be changed simultaneously with changing destinations from the different thread.
+     This test will cause crash if `destinations` property accessed without read lock.
+     */
+    func testChangeLogLevelMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount * 2
+
+        for index in 0..<defaultIterationsCount {
+            oktaLogger.addDestination(testDestination(identifier: "test\(index)"))
+        }
+
+        for iteration in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.removeDestination(withIdentifier: "test\(iteration)")
+                testFinishExpectation.fulfill()
+            }
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.setLogLevel(level: .info, identifiers: ["test\(iteration)"])
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        XCTAssertTrue(oktaLogger.destinations.isEmpty)
+    }
+
+    // MARK: - Destinations modification
+
+    /**
+     Verify that destinations could be added from different threads simultaneously.
+     This test will cause crash if `destinations` property accessed without write lock.
+     */
+    func testAddDestinationsMultithreading() {
+        let addDestinationsExpectation = XCTestExpectation(description: "All destinations should be added")
+        addDestinationsExpectation.expectedFulfillmentCount = defaultIterationsCount
+
+        for index in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.addDestination(self.testDestination(identifier: "test\(index)"))
+                addDestinationsExpectation.fulfill()
+            }
+        }
+
+        wait(for: [addDestinationsExpectation], timeout: defaultTimeout)
+        XCTAssertEqual(oktaLogger.destinations.count, defaultIterationsCount)
+    }
+
+    /**
+     Verify that destinations could be removed from different threads simultaneously.
+     This test will cause crash if `destinations` property accessed without write lock.
+     */
+    func testRemoveDestinationsMultithreading() {
+        let removeDestinationsExpectation = XCTestExpectation(description: "All destinations should be removed")
+        removeDestinationsExpectation.expectedFulfillmentCount = defaultIterationsCount
+
+        for index in 0..<defaultIterationsCount {
+            oktaLogger.addDestination(testDestination(identifier: "test\(index)"))
+        }
+
+        for iteration in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.removeDestination(withIdentifier: "test\(iteration)")
+                removeDestinationsExpectation.fulfill()
+            }
+        }
+
+        wait(for: [removeDestinationsExpectation], timeout: defaultTimeout)
+        XCTAssertTrue(oktaLogger.destinations.isEmpty)
+    }
+
+    // MARK: - Default properties modification
+
+    /**
+     Verify that detault properties can be added simultaneously with changing destinations from the different thread.
+     This test will cause crash if `destinations` property accessed without read lock.
+     */
+    func testAddDefaultPropertiesMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount * 2
+
+        for index in 0..<defaultIterationsCount {
+            oktaLogger.addDestination(testDestination(identifier: "test\(index)"))
+        }
+
+        for iteration in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.removeDestination(withIdentifier: "test\(iteration)")
+                testFinishExpectation.fulfill()
+            }
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.addDefaultProperties(["props\(iteration)": "test"], identifiers: nil)
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        XCTAssertTrue(oktaLogger.destinations.isEmpty)
+    }
+
+    /**
+     Verify that detault properties could be removed simultaneously with changing destinations from the different thread.
+     This test will cause crash if `destinations` property accessed without read lock.
+     */
+    func testRemoveDefaultPropertiesMultithreading() {
+        let testFinishExpectation = XCTestExpectation(description: "")
+        testFinishExpectation.expectedFulfillmentCount = defaultIterationsCount * 2
+
+        for iteration in 0..<defaultIterationsCount {
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.addDestination(self.testDestinationWithProps(identifier: "test\(iteration)"))
+                testFinishExpectation.fulfill()
+            }
+            DispatchQueue.global(qos: .default).async {
+                self.oktaLogger.removeDefaultProperties(for: "props\(iteration)", identifiers: nil)
+                testFinishExpectation.fulfill()
+            }
+        }
+
+        wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        XCTAssertEqual(oktaLogger.destinations.count, defaultIterationsCount)
+    }
+}
+
+private extension OktaLoggerMultithreadingTests {
+
+    func testDestination(identifier: String) -> OktaLoggerDestinationProtocol {
+        return OktaLoggerDestinationBase(identifier: identifier, level: .all, defaultProperties: nil)
+    }
+
+    func testDestinationWithProps(identifier: String) -> OktaLoggerDestinationProtocol {
+        return OktaLoggerDestinationBase(identifier: identifier, level: .all, defaultProperties: Self.testDefaultProperties)
+    }
+
+    static var testDefaultProperties: [String: String] {
+        var result: [String: String] = [:]
+        for iteration in 0..<100 {
+            result["props\(iteration)"] = "test"
+        }
+        return result
+    }
+}

--- a/OktaLoggerTests/OktaLoggerTests.swift
+++ b/OktaLoggerTests/OktaLoggerTests.swift
@@ -312,37 +312,4 @@ class OktaLoggerTests: XCTestCase {
         XCTAssertEqual(oktaLogger.destinations.count, 1)
         XCTAssertNotNil(oktaLogger.destinations["test1"])
     }
-
-    /**
-     Verify that destinations could be mutated fron different threads simultaneously.
-     This test will cause crash if the write sync for `destinations` doesn't work.
-     */
-    func testEditingDestinationsWithConcurrency() {
-        let iterationsCount = 100
-        let oktaLogger = OktaLogger()
-
-        let addDestinationsExpectation = XCTestExpectation(description: "All destinations should be added")
-        addDestinationsExpectation.expectedFulfillmentCount = iterationsCount
-        for iteration in 0..<iterationsCount {
-            DispatchQueue.global(qos: .default).async {
-                oktaLogger.addDestination(
-                    OktaLoggerDestinationBase(identifier: "test\(iteration)", level: .all, defaultProperties: nil)
-                )
-                addDestinationsExpectation.fulfill()
-            }
-        }
-        wait(for: [addDestinationsExpectation], timeout: 5.0)
-        XCTAssertEqual(oktaLogger.destinations.count, iterationsCount)
-
-        let removeDestinationsExpectation = XCTestExpectation(description: "All destinations should be removed")
-        removeDestinationsExpectation.expectedFulfillmentCount = iterationsCount
-        for iteration in 0..<iterationsCount {
-            DispatchQueue.global(qos: .default).async {
-                oktaLogger.removeDestination(withIdentifier: "test\(iteration)")
-                removeDestinationsExpectation.fulfill()
-            }
-        }
-        wait(for: [removeDestinationsExpectation], timeout: 5.0)
-        XCTAssertTrue(oktaLogger.destinations.isEmpty)
-    }
 }


### PR DESCRIPTION
#### Description

- Move multithreading tests to the separate files;
- Add more tests for `OktaLogger`;
- Add more tests for `LumberjackLoggerDelegate`;
- Fix flakiness in the file logger tests;
- Fix possible deadlock threat in `OktaLogger` (more details in the inline comment).

#### Resolves

[OKTA-372991](https://oktainc.atlassian.net/browse/OKTA-372991)

#### Reviewers

@stevelind-okta @AntonVoitsekhivskyi-okta @umangshah-okta 