### PR TITLE
Adding App Center Logging Destination

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.1.2"
+  s.version          = "1.2.0"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
 
   s.subspec "MacOS" do |macos|
     macos.dependency 'OktaLogger/FileLogger'
+    macos.dependency 'OktaLogger/AppCenterLogger'
   end
 
   s.subspec 'FileLogger' do |fileLogger|
@@ -40,12 +41,21 @@ Pod::Spec.new do |s|
     crashlytics.dependency 'OktaLogger/Core'
   end
 
+  s.subspec 'AppCenterLogger' do |appCenterLogger|
+      appCenterLogger.source_files = [
+      'OktaLogger/AppCenterLogger/*'
+      ]
+      appCenterLogger.dependency 'AppCenter', '~>4.1.1'
+      appCenterLogger.dependency 'OktaLogger/Core'
+  end
+
   s.subspec "Core" do |core|
       core.source_files = 'OktaLogger/*.{h,m,swift}'
       core.exclude_files = [
         'OktaLogger/Info.plist',
         'OktaLogger/FileLoggers',
-        'OktaLogger/FirebaseCrashlyticsLogger'
+        'OktaLogger/FirebaseCrashlyticsLogger',
+        'OktaLogger/AppCenterLogger'
       ]
   end
 

--- a/OktaLogger.xcodeproj/project.pbxproj
+++ b/OktaLogger.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		804F18F724C0174800894A52 /* OktaLoggerFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804F18F624C0174800894A52 /* OktaLoggerFileLoggerTests.swift */; };
 		806FF25E24B95A3300994D4D /* OktaLoggerFileLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806FF25D24B95A3300994D4D /* OktaLoggerFileLogger.swift */; };
 		80AA110224BE799800981074 /* DemoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA110124BE799800981074 /* DemoTableViewCell.swift */; };
+		8DCF5F682644B25D008698CD /* AppCenterLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCF5F672644B25D008698CD /* AppCenterLogger.swift */; };
 		B3E071E3B33C4657A8B4381B /* libPods-OktaLogger.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 62BB891524DBDEF8FC8E9711 /* libPods-OktaLogger.a */; };
 		C4AA0759EDAC342A3B6B6796 /* libPods-OktaLoggerTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFB48B8C0D4F4DD1D258FFD /* libPods-OktaLoggerTests.a */; };
 		D52C2AD12474A4F5003CCF4D /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52C2AD02474A4F5003CCF4D /* ReadWriteLock.swift */; };
@@ -26,11 +27,11 @@
 		D5C824E32469DBF1005CF747 /* OktaLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C824E22469DBF1005CF747 /* OktaLoggerTests.swift */; };
 		D5C824E52469DBF1005CF747 /* OktaLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = D5C824D72469DBF1005CF747 /* OktaLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5D0978E246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */; };
+		DE1A7B3925EFF432007A5F60 /* LoggerDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1A7B3825EFF432007A5F60 /* LoggerDemoViewModel.swift */; };
 		DE2FFE21260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FFE20260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift */; };
 		DE504DC425BEE84A00B27BDD /* OktaLoggerFileLogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE504DC325BEE84A00B27BDD /* OktaLoggerFileLogFormatter.swift */; };
-		DEABAFC9260C7C0100DB7008 /* FileTestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEABAFC8260C7C0100DB7008 /* FileTestsHelper.swift */; };
-		DE1A7B3925EFF432007A5F60 /* LoggerDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1A7B3825EFF432007A5F60 /* LoggerDemoViewModel.swift */; };
 		DE6A163725F1120100B0FBA0 /* LogsBrowseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6A163625F1120100B0FBA0 /* LogsBrowseViewController.swift */; };
+		DEABAFC9260C7C0100DB7008 /* FileTestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEABAFC8260C7C0100DB7008 /* FileTestsHelper.swift */; };
 		DEC5276624DBF9630022B698 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DEC5276524DBF9630022B698 /* GoogleService-Info.plist */; };
 		DEF2CC23260A341300F8B644 /* OktaLoggerMultithreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF2CC22260A341300F8B644 /* OktaLoggerMultithreadingTests.swift */; };
 		DEFB59E124EAC76400A1744F /* OktaLoggerFirebaseCrashlyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB59E024EAC76300A1744F /* OktaLoggerFirebaseCrashlyticsLogger.swift */; };
@@ -101,6 +102,7 @@
 		806FF25D24B95A3300994D4D /* OktaLoggerFileLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLogger.swift; sourceTree = "<group>"; };
 		80AA110124BE799800981074 /* DemoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTableViewCell.swift; sourceTree = "<group>"; };
 		80DDE79324B972FC00D0E2F3 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		8DCF5F672644B25D008698CD /* AppCenterLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCenterLogger.swift; sourceTree = "<group>"; };
 		C58A9E54B6CE1A902894264C /* Pods-OktaLoggerDemoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLoggerDemoApp.debug.xcconfig"; path = "Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp.debug.xcconfig"; sourceTree = "<group>"; };
 		D52C2AD02474A4F5003CCF4D /* ReadWriteLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		D54461C02469FFBA00C755F1 /* OktaLoggerLogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerLogLevel.swift; sourceTree = "<group>"; };
@@ -119,11 +121,11 @@
 		D5C824E42469DBF1005CF747 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerConsoleLoggerTests.swift; sourceTree = "<group>"; };
 		DB510C00105E7489E2C16BA3 /* Pods-OktaLoggerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLoggerTests.debug.xcconfig"; path = "Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		DE1A7B3825EFF432007A5F60 /* LoggerDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerDemoViewModel.swift; sourceTree = "<group>"; };
 		DE2FFE20260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLoggerMultithreadingTests.swift; sourceTree = "<group>"; };
 		DE504DC325BEE84A00B27BDD /* OktaLoggerFileLogFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLogFormatter.swift; sourceTree = "<group>"; };
-		DEABAFC8260C7C0100DB7008 /* FileTestsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTestsHelper.swift; sourceTree = "<group>"; };
-		DE1A7B3825EFF432007A5F60 /* LoggerDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerDemoViewModel.swift; sourceTree = "<group>"; };
 		DE6A163625F1120100B0FBA0 /* LogsBrowseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsBrowseViewController.swift; sourceTree = "<group>"; };
+		DEABAFC8260C7C0100DB7008 /* FileTestsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTestsHelper.swift; sourceTree = "<group>"; };
 		DEC5276524DBF9630022B698 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		DEF2CC22260A341300F8B644 /* OktaLoggerMultithreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerMultithreadingTests.swift; sourceTree = "<group>"; };
 		DEFB59E024EAC76300A1744F /* OktaLoggerFirebaseCrashlyticsLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerFirebaseCrashlyticsLogger.swift; sourceTree = "<group>"; };
@@ -180,6 +182,14 @@
 			path = FileLoggers;
 			sourceTree = "<group>";
 		};
+		8DCF5F662644B23F008698CD /* AppCenterLogger */ = {
+			isa = PBXGroup;
+			children = (
+				8DCF5F672644B25D008698CD /* AppCenterLogger.swift */,
+			);
+			path = AppCenterLogger;
+			sourceTree = "<group>";
+		};
 		9200B49349EABD23B114BB0F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -218,6 +228,7 @@
 		D5C824D62469DBF1005CF747 /* OktaLogger */ = {
 			isa = PBXGroup;
 			children = (
+				8DCF5F662644B23F008698CD /* AppCenterLogger */,
 				8004832F24C1F0F0008BFF3A /* FileLoggers */,
 				DEFB59DF24EAC76300A1744F /* FirebaseCrashlyticsLogger */,
 				D5C824D72469DBF1005CF747 /* OktaLogger.h */,
@@ -557,6 +568,7 @@
 				D54461C3246A023000C755F1 /* OktaLogger.swift in Sources */,
 				D54461CB246B55A600C755F1 /* OktaLoggerDestination.swift in Sources */,
 				8004832E24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift in Sources */,
+				8DCF5F682644B25D008698CD /* AppCenterLogger.swift in Sources */,
 				806FF25E24B95A3300994D4D /* OktaLoggerFileLogger.swift in Sources */,
 				D52C2AD12474A4F5003CCF4D /* ReadWriteLock.swift in Sources */,
 				6582A2024047A1BC55BC98D3 /* LumberjackLoggerDelegate.swift in Sources */,

--- a/OktaLogger/AppCenterLogger/AppCenterLogger.swift
+++ b/OktaLogger/AppCenterLogger/AppCenterLogger.swift
@@ -1,0 +1,28 @@
+//
+// Created by Brenner Ryan on 5/11/21.
+// Copyright (c) 2021 Okta, Inc. All rights reserved.
+//
+
+import AppCenterAnalytics
+
+/**
+ Concrete logging class for App Center events.
+ */
+class AppCenterLogger: OktaLoggerDestinationBase {
+    override open func log(level: OktaLoggerLogLevel, eventName: String, message: String?, properties: [AnyHashable: Any]?, file: String, line: NSNumber, funcName: String) {
+        switch level {
+        case .error:
+            guard let propertiesStrings = properties as? [String: String] else {
+                Analytics.trackEvent(eventName)
+                return
+            }
+            Analytics.trackEvent(eventName, withProperties: propertiesStrings, flags: .critical)
+        default:
+            guard let propertiesStrings = properties as? [String: String] else {
+                Analytics.trackEvent(eventName)
+                return
+            }
+            Analytics.trackEvent(eventName, withProperties: propertiesStrings)
+        }
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,7 @@ platform :ios, '11.0'
 use_modular_headers!
 
 target 'OktaLogger' do
+    pod 'AppCenter', '~>4.1.1'
     pod 'Firebase/Crashlytics', '~>7.4.0'
     pod 'CocoaLumberjack/Swift', '~>3.6.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,4 +1,12 @@
 PODS:
+  - AppCenter (4.1.1):
+    - AppCenter/Analytics (= 4.1.1)
+    - AppCenter/Crashes (= 4.1.1)
+  - AppCenter/Analytics (4.1.1):
+    - AppCenter/Core
+  - AppCenter/Core (4.1.1)
+  - AppCenter/Crashes (4.1.1):
+    - AppCenter/Core
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
@@ -40,20 +48,20 @@ PODS:
     - nanopb/encode (= 2.30907.0)
   - nanopb/decode (2.30907.0)
   - nanopb/encode (2.30907.0)
-  - OktaLogger (1.1.2):
-    - OktaLogger/Complete (= 1.1.2)
+  - OktaLogger (1.2.0):
+    - OktaLogger/Complete (= 1.2.0)
     - SwiftLint
-  - OktaLogger/Complete (1.1.2):
+  - OktaLogger/Complete (1.2.0):
     - OktaLogger/FileLogger
     - OktaLogger/FirebaseCrashlytics
     - SwiftLint
-  - OktaLogger/Core (1.1.2):
+  - OktaLogger/Core (1.2.0):
     - SwiftLint
-  - OktaLogger/FileLogger (1.1.2):
+  - OktaLogger/FileLogger (1.2.0):
     - CocoaLumberjack/Swift (~> 3.6.0)
     - OktaLogger/Core
     - SwiftLint
-  - OktaLogger/FirebaseCrashlytics (1.1.2):
+  - OktaLogger/FirebaseCrashlytics (1.2.0):
     - Firebase/Crashlytics (~> 7.4.0)
     - OktaLogger/Core
     - SwiftLint
@@ -61,15 +69,15 @@ PODS:
   - SwiftLint (0.39.2)
 
 DEPENDENCIES:
+  - AppCenter (~> 4.1.1)
   - CocoaLumberjack/Swift (~> 3.6.0)
   - Firebase/Crashlytics (~> 7.4.0)
   - OktaLogger (from `.`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
-    - CocoaLumberjack
-    - SwiftLint
   trunk:
+    - AppCenter
+    - CocoaLumberjack
     - Firebase
     - FirebaseCore
     - FirebaseCoreDiagnostics
@@ -79,12 +87,14 @@ SPEC REPOS:
     - GoogleUtilities
     - nanopb
     - PromisesObjC
+    - SwiftLint
 
 EXTERNAL SOURCES:
   OktaLogger:
     :path: "."
 
 SPEC CHECKSUMS:
+  AppCenter: cd53e3ed3563cc720bcb806c9731a12389b40d44
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
   Firebase: 09fb40287b6dfc8ee65f726fa0b788719d3f2a07
   FirebaseCore: 99c06e5a1e8d6952e75cb1f0a6d0b23c0f5ccdcf
@@ -94,10 +104,10 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 1024b1a4dfbd7a0e92cb20d7e0a6f1fb66b449a4
   GoogleUtilities: 31c5b01f978a70c6cff2afc6272b3f1921614b43
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
-  OktaLogger: f8f1c20b9af20dd30e5c5e0136cf6108046a0e5c
+  OktaLogger: 88bee0372ff1edb302006057286fdeb6e78858b6
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
-PODFILE CHECKSUM: 56d87b5cb773d85ba14abcf465af02c04739eccb
+PODFILE CHECKSUM: 0d62d957d380013c75e13aeb32bd0c568a713007
 
 COCOAPODS: 1.10.1

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Destination is an entity which perform log operation according to its implementa
 1. [Console (OktaLoggerConsoleLogger)](#console-destination)
 2. [File (OktaLoggerFileLogger)](#file-destination)
 3. [Firebase (OktaLoggerFirebaseCrashlyticsLogger)](#firebase-crashlytics-destination)
+4. [AppCenter (AppCenterLogger)](#app-center-destination)
 
 All of the default logging destinations are thread-safe and could be used from any thread.
 
@@ -128,6 +129,20 @@ There are few important features and restrictions in this destination:
 - Fatal and non-fatal error reports is sent on the next app launch.
 
 This destination is using [Firebase Crashlytics SDK](https://github.com/firebase/firebase-ios-sdk) for logging implementation.
+
+### App Center destination
+
+Related class -
+[AppCenterLogger]
+(OktaLogger/AppCenterLogger/AppCenterLogger.swift).
+This destination uses the AppCenter SDK to send events, so they can be accessed from the App Center console. The only functionality supported by this destination is sending events to the App Center dashboard.
+There are a few important features and restrictions in this destination:
+
+- Logger will not send events unless App Center is already configured in AppDelegate [setup App Center](https://docs.microsoft.com/en-us/appcenter/sdk/getting-started/macos).
+- Logs with 'error' levels are sent as critical events to App Center [event flags](https://docs.microsoft.com/en-us/appcenter/sdk/analytics/macos)
+- Log messages are ignored so they can be left as nil. The eventName parameter is the name of the event sent to App Center, and properties are sent as the properties of the event. Make sure that the properties are in [String: String] format or they may not be sent to App Center
+
+This destination is using [App Center SDK](https://github.com/microsoft/appcenter-sdk-apple) for logging implementation
 
 ### Custom destinations
 


### PR DESCRIPTION
Adding destination for App Center. App Center does not have full logging capabilities, and we are using it on mac side since firebase is not officially supported for macos yet. App Center supports events, where these events have two components: eventName, and a [String: String] dictionary of properties. This destination is designed to send an event to App Center upon log being called. Configuration of App Center happens in app delegate, therefore this destination contains no configuration parameters, it simply calls the app center event tracking function, assuming the user of the destination has configured it properly.