### PR TITLE
Change Instabug dependency version to less restrictive.

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.3.0"
+  s.version          = "1.3.1"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -57,7 +57,7 @@ Pod::Spec.new do |s|
       instabugLogger.ios.source_files = [
         'OktaLogger/InstabugLogger/*'
       ]
-      instabugLogger.ios.dependency 'Instabug', '~>10.7.5'
+      instabugLogger.ios.dependency 'Instabug', '~> 10.7'
       instabugLogger.ios.dependency 'OktaLogger/Core'
   end
 


### PR DESCRIPTION
#### Description

Change Instabug dependency version to `~> 10.7`, so the host app can use newer (10.x.x) versions of this SDK.