### PR TITLE
Merge logged properties into userInfo dict for Firebase Logger

### DIFF
--- a/OktaLogger.playground/Pages/FileLogger.xcplaygroundpage/Contents.swift
+++ b/OktaLogger.playground/Pages/FileLogger.xcplaygroundpage/Contents.swift
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import UIKit
 import OktaLogger
 

--- a/OktaLogger.playground/Pages/Home.xcplaygroundpage/Contents.swift
+++ b/OktaLogger.playground/Pages/Home.xcplaygroundpage/Contents.swift
@@ -1,2 +1,15 @@
+/*
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
 //: # OktaLogger Documentation
 //: - [How to Use a File Logger?](FileLogger)

--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.3.4"
+  s.version          = "1.3.5"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"

--- a/OktaLogger.xcodeproj/project.pbxproj
+++ b/OktaLogger.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 				D5C824D12469DBF1005CF747 /* Frameworks */,
 				D5C824D22469DBF1005CF747 /* Resources */,
 				80DDE78E24B962C900D0E2F3 /* Embed Frameworks */,
+				7B0C4EE7276D1DAC0033BDC6 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -573,6 +574,24 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		7B0C4EE7276D1DAC0033BDC6 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --config \"${PROJECT_DIR}/.swiftlint.yml\"\n";
 		};
 		9ECAD1E0171C5273C443BE35 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/OktaLogger.xcodeproj/project.pbxproj
+++ b/OktaLogger.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6582A2024047A1BC55BC98D3 /* LumberjackLoggerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6582AABCF4A4B6E5E05FC2E4 /* LumberjackLoggerDelegate.swift */; };
 		6582A2C33C06B4353D1538E3 /* FileLoggerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6582ABCA2C9C2759535A1B4E /* FileLoggerDelegate.swift */; };
+		7B13559F276BE69400F0516C /* OktaLoggerFirebaseLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B13559E276BE69400F0516C /* OktaLoggerFirebaseLoggerTests.swift */; };
 		8004832E24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8004832D24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift */; };
 		804F18F724C0174800894A52 /* OktaLoggerFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804F18F624C0174800894A52 /* OktaLoggerFileLoggerTests.swift */; };
 		806FF25E24B95A3300994D4D /* OktaLoggerFileLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806FF25D24B95A3300994D4D /* OktaLoggerFileLogger.swift */; };
@@ -100,6 +101,7 @@
 		6582AABCF4A4B6E5E05FC2E4 /* LumberjackLoggerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LumberjackLoggerDelegate.swift; sourceTree = "<group>"; };
 		6582ABCA2C9C2759535A1B4E /* FileLoggerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLoggerDelegate.swift; sourceTree = "<group>"; };
 		672ADCC5504F41DBB4546AB0 /* Pods-OktaLogger_.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OktaLogger_.debug.xcconfig"; path = "Target Support Files/Pods-OktaLogger_/Pods-OktaLogger_.debug.xcconfig"; sourceTree = "<group>"; };
+		7B13559E276BE69400F0516C /* OktaLoggerFirebaseLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerFirebaseLoggerTests.swift; sourceTree = "<group>"; };
 		8004832D24C1EFDF008BFF3A /* OktaLoggerFileLoggerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLoggerConfig.swift; sourceTree = "<group>"; };
 		804F18F624C0174800894A52 /* OktaLoggerFileLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLoggerTests.swift; sourceTree = "<group>"; };
 		806FF25D24B95A3300994D4D /* OktaLoggerFileLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaLoggerFileLogger.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				DE2FFE20260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift */,
 				D5D0978D246DE00800C1362F /* OktaLoggerConsoleLoggerTests.swift */,
 				DEE498C626C1139A00487014 /* OktaLoggerInstabugLoggerTests.swift */,
+				7B13559E276BE69400F0516C /* OktaLoggerFirebaseLoggerTests.swift */,
 				D5D0978A246CB52900C1362F /* Helpers */,
 				D5C824E42469DBF1005CF747 /* Info.plist */,
 				D5B22D07246C8E39007ECC2F /* OktaLoggerTests-Bridging-Header.h */,
@@ -642,6 +645,7 @@
 				DE2FFE21260B89650028CAD6 /* OktaLoggerFileLoggerMultithreadingTests.swift in Sources */,
 				D5C824E32469DBF1005CF747 /* OktaLoggerTests.swift in Sources */,
 				DEF2CC23260A341300F8B644 /* OktaLoggerMultithreadingTests.swift in Sources */,
+				7B13559F276BE69400F0516C /* OktaLoggerFirebaseLoggerTests.swift in Sources */,
 				D5B22D0B246CA47E007ECC2F /* MockLoggerDestination.swift in Sources */,
 				E2E7C95325196D83006B8DAE /* OktaLoggerDefaultPropertiesTests.swift in Sources */,
 			);

--- a/OktaLogger/AppCenterLogger/AppCenterLogger.swift
+++ b/OktaLogger/AppCenterLogger/AppCenterLogger.swift
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import AppCenterAnalytics
 
 /**

--- a/OktaLogger/FileLoggers/DDLogFileManagerCustomName.swift
+++ b/OktaLogger/FileLoggers/DDLogFileManagerCustomName.swift
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import Foundation
 import CocoaLumberjack
 

--- a/OktaLogger/FileLoggers/LumberjackLoggerDelegate.swift
+++ b/OktaLogger/FileLoggers/LumberjackLoggerDelegate.swift
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import CocoaLumberjack
 
 class LumberjackLoggerDelegate: FileLoggerDelegate {

--- a/OktaLogger/FileLoggers/OktaLoggerFileLogFormatter.swift
+++ b/OktaLogger/FileLoggers/OktaLoggerFileLogFormatter.swift
@@ -9,12 +9,6 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
-//
-//  OktaLoggerFileLogFormatter.swift
-//  OktaLogger
-//
-//  Created by Borys Kasianenko on 1/25/21.
-//
 
 import Foundation
 import CocoaLumberjack

--- a/OktaLogger/FileLoggers/OktaLoggerFileLogger.swift
+++ b/OktaLogger/FileLoggers/OktaLoggerFileLogger.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import Foundation
 
 @objc

--- a/OktaLogger/FileLoggers/OktaLoggerFileLoggerConfig.swift
+++ b/OktaLogger/FileLoggers/OktaLoggerFileLoggerConfig.swift
@@ -9,7 +9,9 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import Foundation
+
 @objc
 public class OktaLoggerFileLoggerConfig: NSObject {
 

--- a/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift
+++ b/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import FirebaseCrashlytics
 
 /**
@@ -91,7 +92,7 @@ open class OktaLoggerFirebaseCrashlyticsLogger: OktaLoggerDestinationBase {
         let normalizedEventName = eventName.lowercased().replacingOccurrences(of: " ", with: "-")
         return "\(identifier).\(normalizedEventName)"
     }
-    
+
     class func createUserInfoDict(level: OktaLoggerLogLevel,
                                   eventName: String,
                                   message: String?,
@@ -108,19 +109,19 @@ open class OktaLoggerFirebaseCrashlyticsLogger: OktaLoggerDestinationBase {
             "line": line,
             "function": funcName
         ]
-        
+
         // merge destination-level properties into userInfo (high priority)
         if let defaultProperties = defaultProperties as? [String: Any],
            !defaultProperties.isEmpty {
             userInfo.merge(defaultProperties) { (_, last) in last }
         }
-        
+
         // merge log-level properties into userInfo (highest priority)
         if let properties = properties as? [String: Any],
            !properties.isEmpty {
             userInfo.merge(properties) { (_, last) in last }
         }
-        
+
         return userInfo
     }
 }

--- a/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift
+++ b/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift
@@ -93,9 +93,9 @@ open class OktaLoggerFirebaseCrashlyticsLogger: OktaLoggerDestinationBase {
     }
     
     class func createUserInfoDict(level: OktaLoggerLogLevel,
-                            eventName: String,
-                            message: String?,
-                            properties: [AnyHashable: Any]?,
+                                  eventName: String,
+                                  message: String?,
+                                  properties: [AnyHashable: Any]?,
                                   defaultProperties: [AnyHashable: Any]?,
                                   file: String,
                                   line: NSNumber,

--- a/OktaLogger/InstabugLogger/OktaLoggerInstabugLogger.swift
+++ b/OktaLogger/InstabugLogger/OktaLoggerInstabugLogger.swift
@@ -12,9 +12,7 @@
 
 import Instabug
 
-/**
- Concrete logging class for Instabug.
- */
+///  Concrete logging destination for Instabug
 open class OktaLoggerInstabugLogger: OktaLoggerDestinationBase {
 
     override open func log(level: OktaLoggerLogLevel, eventName: String, message: String?, properties: [AnyHashable: Any]?, file: String, line: NSNumber, funcName: String) {
@@ -47,7 +45,7 @@ open class OktaLoggerInstabugLogger: OktaLoggerDestinationBase {
         }
     }
 
-    open override func stringValue(level: OktaLoggerLogLevel, eventName: String, message: String?, file: String, line: NSNumber, funcName: String) -> String {
+    override open func stringValue(level: OktaLoggerLogLevel, eventName: String, message: String?, file: String, line: NSNumber, funcName: String) -> String {
         let fileLogString = file.split(separator: "/").last ?? ""
         let messageLogString: String = {
             guard let message = message else {

--- a/OktaLogger/OktaLogger.swift
+++ b/OktaLogger/OktaLogger.swift
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import Foundation
 
 /**
@@ -136,7 +137,7 @@ open class OktaLogger: NSObject, OktaLoggerProtocol {
         self.loggingDestinations = destinationDict
     }
 
-    public convenience override init() {
+    override public convenience init() {
         self.init(destinations: [])
     }
 

--- a/OktaLogger/OktaLoggerDestination.swift
+++ b/OktaLogger/OktaLoggerDestination.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import Foundation
 
 /**

--- a/OktaLogger/OktaLoggerDestination.swift
+++ b/OktaLogger/OktaLoggerDestination.swift
@@ -155,13 +155,15 @@ open class OktaLoggerDestinationBase: NSObject, OktaLoggerDestinationProtocol {
     }
 
     open func addDefaultProperties(_ defaultProperties: [AnyHashable: Any]) {
-        self.defaultProperties.merge(defaultProperties, uniquingKeysWith: { (_, last) in last })
-        self.defaultPropertiesDescription = Self.description(of: self._defaultProperties)
+        var updatedProperties = self.defaultProperties
+        updatedProperties.merge(defaultProperties, uniquingKeysWith: { (_, last) in last })
+        self.defaultProperties = updatedProperties
     }
 
     open func removeDefaultProperties(for key: AnyHashable) {
-        defaultProperties.removeValue(forKey: key)
-        self.defaultPropertiesDescription = Self.description(of: self._defaultProperties)
+        var updatedProperties = defaultProperties
+        updatedProperties.removeValue(forKey: key)
+        defaultProperties = updatedProperties
     }
 
 

--- a/OktaLoggerTests/Helpers/FileTestsHelper.swift
+++ b/OktaLoggerTests/Helpers/FileTestsHelper.swift
@@ -53,7 +53,8 @@ class FileTestsHelper {
         try? FileManager.default.removeItem(at: FileTestsHelper.testLogsFolder)
     }
 
-    static private var testLogsFolder: URL {
+    // swiftlint:disable force_unwrapping
+    private static var testLogsFolder: URL {
         return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
             .appendingPathComponent("TestLogs", isDirectory: true)
     }

--- a/OktaLoggerTests/OktaLoggerFileLoggerMultithreadingTests.swift
+++ b/OktaLoggerTests/OktaLoggerFileLoggerMultithreadingTests.swift
@@ -70,7 +70,7 @@ class OktaLoggerFileLoggerMultithreadingTests: XCTestCase {
         }
 
         wait(for: [testFinishExpectation], timeout: defaultTimeout)
-        
+
         let purgeExpectation = expectation(description: "Purge logs from main thread")
         lumberjackDelegate.purgeLogs()
         DispatchQueue.main.async {

--- a/OktaLoggerTests/OktaLoggerFileLoggerMultithreadingTests.swift
+++ b/OktaLoggerTests/OktaLoggerFileLoggerMultithreadingTests.swift
@@ -70,7 +70,13 @@ class OktaLoggerFileLoggerMultithreadingTests: XCTestCase {
         }
 
         wait(for: [testFinishExpectation], timeout: defaultTimeout)
+        
+        let purgeExpectation = expectation(description: "Purge logs from main thread")
         lumberjackDelegate.purgeLogs()
+        DispatchQueue.main.async {
+            purgeExpectation.fulfill()
+        }
+        wait(for: [purgeExpectation], timeout: 1.0)
         XCTAssertTrue(lumberjackDelegate.getLogs().isEmpty)
     }
 }

--- a/OktaLoggerTests/OktaLoggerFirebaseLoggerTests.swift
+++ b/OktaLoggerTests/OktaLoggerFirebaseLoggerTests.swift
@@ -13,8 +13,7 @@ import XCTest
 @testable import OktaLogger
 
 class OktaLoggerFirebaseLoggerTests: XCTestCase {
-
-  
+    
     ///  Verify that the userInfo dict is created as expected
     ///  defaultProperties and logged properties should be merged into the userInfo dict in correct priority
     func testUserInfoMerge() {
@@ -51,7 +50,6 @@ class OktaLoggerFirebaseLoggerTests: XCTestCase {
         XCTAssertEqual(userInfo["function"] as? String, funcName)
         XCTAssertEqual(userInfo["override"] as? String, "SUCCESS")
         XCTAssertEqual(userInfo["file"] as? String, "<REDACTED>")
-
     }
 
 }

--- a/OktaLoggerTests/OktaLoggerFirebaseLoggerTests.swift
+++ b/OktaLoggerTests/OktaLoggerFirebaseLoggerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 @testable import OktaLogger
 
 class OktaLoggerFirebaseLoggerTests: XCTestCase {
-    
+
     ///  Verify that the userInfo dict is created as expected
     ///  defaultProperties and logged properties should be merged into the userInfo dict in correct priority
     func testUserInfoMerge() {
@@ -22,7 +22,7 @@ class OktaLoggerFirebaseLoggerTests: XCTestCase {
         let pushToken = UUID().uuidString
         let properties = [
             "pushToken": pushToken,
-            "override" : "SUCCESS"
+            "override": "SUCCESS"
         ]
         let appInstanceId = UUID().uuidString
         let file = UUID().uuidString
@@ -41,7 +41,7 @@ class OktaLoggerFirebaseLoggerTests: XCTestCase {
                                                                               file: file,
                                                                               line: line,
                                                                               funcName: funcName)
-        
+
         XCTAssertEqual(userInfo["eventName"] as? String, eventName)
         XCTAssertEqual(userInfo["message"] as? String, message)
         XCTAssertEqual(userInfo["pushToken"] as? String, pushToken)

--- a/OktaLoggerTests/OktaLoggerFirebaseLoggerTests.swift
+++ b/OktaLoggerTests/OktaLoggerFirebaseLoggerTests.swift
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+import XCTest
+@testable import OktaLogger
+
+class OktaLoggerFirebaseLoggerTests: XCTestCase {
+
+  
+    ///  Verify that the userInfo dict is created as expected
+    ///  defaultProperties and logged properties should be merged into the userInfo dict in correct priority
+    func testUserInfoMerge() {
+        let eventName = UUID().uuidString
+        let message = UUID().uuidString
+        let pushToken = UUID().uuidString
+        let properties = [
+            "pushToken": pushToken,
+            "override" : "SUCCESS"
+        ]
+        let appInstanceId = UUID().uuidString
+        let file = UUID().uuidString
+        let defaultProperties = [
+            "appInstanceId": appInstanceId,
+            "override": "FAIL",
+            "file": "<REDACTED>"
+        ]
+        let line = NSNumber(integerLiteral: 33)
+        let funcName = UUID().uuidString
+        let userInfo = OktaLoggerFirebaseCrashlyticsLogger.createUserInfoDict(level: .warning,
+                                                                              eventName: eventName,
+                                                                              message: message,
+                                                                              properties: properties,
+                                                                              defaultProperties: defaultProperties,
+                                                                              file: file,
+                                                                              line: line,
+                                                                              funcName: funcName)
+        
+        XCTAssertEqual(userInfo["eventName"] as? String, eventName)
+        XCTAssertEqual(userInfo["message"] as? String, message)
+        XCTAssertEqual(userInfo["pushToken"] as? String, pushToken)
+        XCTAssertEqual(userInfo["appInstanceId"] as? String, appInstanceId)
+        XCTAssertEqual(userInfo["line"] as? NSNumber, line)
+        XCTAssertEqual(userInfo["function"] as? String, funcName)
+        XCTAssertEqual(userInfo["override"] as? String, "SUCCESS")
+        XCTAssertEqual(userInfo["file"] as? String, "<REDACTED>")
+
+    }
+
+}


### PR DESCRIPTION
Propagate properties dict from `log.warning()` and `log.error()` into firebase destination.
Added Unit test for `userInfo` dict creation
Fix multithreading issue with default properties