### PR TITLE
OKTA-490663 - iOS Push SDK: Get rid of static-only limitation in OktaLogger library

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.3.5"
+  s.version          = "1.3.6"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -13,19 +13,12 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.dependency 'SwiftLint'
   s.default_subspec = "Complete"
-  s.static_framework = true
 
   # Subspec
   s.subspec "Complete" do |complete|
     complete.dependency 'OktaLogger/FileLogger'
     complete.dependency 'OktaLogger/FirebaseCrashlytics'
     complete.dependency 'OktaLogger/InstabugLogger'
-  end
-
-  s.subspec "MacOS" do |macos|
-    macos.osx.deployment_target = '10.14'
-    macos.dependency 'OktaLogger/FileLogger'
-    macos.dependency 'OktaLogger/AppCenterLogger'
   end
 
   s.subspec 'FileLogger' do |fileLogger|
@@ -42,15 +35,6 @@ Pod::Spec.new do |s|
     ]
     crashlytics.dependency 'Firebase/Crashlytics', '~> 8.0'
     crashlytics.dependency 'OktaLogger/Core'
-  end
-
-  s.subspec 'AppCenterLogger' do |appCenterLogger|
-    appCenterLogger.osx.deployment_target = '10.14'
-    appCenterLogger.source_files = [
-    'OktaLogger/AppCenterLogger/*'
-    ]
-    appCenterLogger.dependency 'AppCenter', '~>4.3.0'
-    appCenterLogger.dependency 'OktaLogger/Core'
   end
 
   s.subspec 'InstabugLogger' do |instabugLogger|

--- a/OktaLogger/AppCenterLogger/AppCenterLogger.swift
+++ b/OktaLogger/AppCenterLogger/AppCenterLogger.swift
@@ -11,6 +11,7 @@
  */
 
 import AppCenterAnalytics
+import OktaLogger
 
 /**
  Concrete logging class for App Center events.

--- a/OktaLoggerAppCenter.podspec
+++ b/OktaLoggerAppCenter.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name             = "OktaLoggerAppCenter"
+  s.version          = "1.0.0"
+  s.summary          = "Implementation of AppCenter logger destination"
+  s.description      = "Implementation of AppCenter logger destination. Requires OktaLogger/Core"
+  s.homepage         = "https://github.com/okta/okta-logger-swift"
+  s.license          = { :type => 'APACHE2', :file => 'LICENSE' }
+  s.author           = { "Okta Developers" => "developer@okta.com" }
+  s.source           = { :git => "https://github.com/okta/okta-logger-swift.git",  :tag => s.version.to_s }
+  s.osx.deployment_target = '10.14'
+  s.swift_version = '5.0'
+  s.dependency 'SwiftLint'
+  s.static_framework = true
+  
+  s.source_files = [
+    'OktaLogger/AppCenterLogger/*'
+    ]
+  s.dependency 'AppCenter','~>4.3.0'
+  s.dependency 'OktaLogger/Core'
+end


### PR DESCRIPTION
Work done:
- Pushed cocoapods release to global trunk - latest 1.3.5
- Moved out AppCenter integration into separate spec since AppCenter causes certain constraints to OktaLogger library
- Push new OktaLogger and OktaLoggerAppCenter specs into cocoapods trunk(1.3.6) - TBD

Future usage in Mac OV:
```
def okta_logger
  pod 'OktaLoggerAppCenter'
  pod 'OktaLogger/FileLogger'
end
```