### PR TITLE
OKTA-526873 - Update FirebaseSDK to 9.4.0

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.4.0"
+  s.version          = "1.4.1"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     crashlytics.source_files = [
       'Sources/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift'
     ]
-    crashlytics.dependency 'Firebase/Crashlytics', '~> 8.0'
+    crashlytics.dependency 'Firebase/Crashlytics', '~> 9.0'
     crashlytics.dependency 'OktaLogger/Core'
   end
 

--- a/Podfile
+++ b/Podfile
@@ -3,14 +3,14 @@ use_modular_headers!
 
 target 'OktaLogger' do
     pod 'AppCenter', '~>4.3.0'
-    pod 'Firebase/Crashlytics', '8.9.1'
+    pod 'Firebase/Crashlytics', '9.4.0'
     pod 'CocoaLumberjack/Swift', '~>3.6.0'
     pod 'Instabug', '11.0.1'
 end
 
 target 'OktaLoggerDemoApp' do
     pod 'OktaLogger', :path => '.'
-    pod 'Firebase/Crashlytics', '8.9.1'
+    pod 'Firebase/Crashlytics', '9.4.0'
 
     target 'OktaLoggerTests' do
       inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,33 +10,36 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - Firebase/CoreOnly (8.9.1):
-    - FirebaseCore (= 8.9.1)
-  - Firebase/Crashlytics (8.9.1):
+  - Firebase/CoreOnly (9.4.0):
+    - FirebaseCore (= 9.4.0)
+  - Firebase/Crashlytics (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.9.0)
-  - FirebaseCore (8.9.1):
-    - FirebaseCoreDiagnostics (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/Logger (~> 7.6)
-  - FirebaseCoreDiagnostics (8.15.0):
-    - GoogleDataTransport (~> 9.1)
+    - FirebaseCrashlytics (~> 9.4.0)
+  - FirebaseCore (9.4.0):
+    - FirebaseCoreDiagnostics (~> 9.0)
+    - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-    - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.9.0):
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleDataTransport (~> 9.1)
-    - GoogleUtilities/Environment (~> 7.6)
-    - nanopb (~> 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseInstallations (8.15.0):
-    - FirebaseCore (~> 8.0)
+  - FirebaseCoreDiagnostics (9.4.0):
+    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseCoreInternal (9.4.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+  - FirebaseCrashlytics (9.4.0):
+    - FirebaseCore (~> 9.0)
+    - FirebaseInstallations (~> 9.0)
+    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - PromisesObjC (~> 2.1)
+  - FirebaseInstallations (9.4.0):
+    - FirebaseCore (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleDataTransport (9.1.4):
+    - PromisesObjC (~> 2.1)
+  - GoogleDataTransport (9.2.0):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
@@ -44,14 +47,15 @@ PODS:
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
   - GoogleUtilities/UserDefaults (7.7.0):
     - GoogleUtilities/Logger
   - Instabug (11.0.1)
-  - nanopb (2.30908.0):
-    - nanopb/decode (= 2.30908.0)
-    - nanopb/encode (= 2.30908.0)
-  - nanopb/decode (2.30908.0)
-  - nanopb/encode (2.30908.0)
+  - nanopb (2.30909.0):
+    - nanopb/decode (= 2.30909.0)
+    - nanopb/encode (= 2.30909.0)
+  - nanopb/decode (2.30909.0)
+  - nanopb/encode (2.30909.0)
   - OktaLogger (1.4.0):
     - OktaLogger/Complete (= 1.4.0)
     - SwiftLint
@@ -67,20 +71,20 @@ PODS:
     - OktaLogger/Core
     - SwiftLint
   - OktaLogger/FirebaseCrashlytics (1.4.0):
-    - Firebase/Crashlytics (~> 8.0)
+    - Firebase/Crashlytics (~> 9.0)
     - OktaLogger/Core
     - SwiftLint
   - OktaLogger/InstabugLogger (1.4.0):
     - Instabug (= 11.0.1)
     - OktaLogger/Core
     - SwiftLint
-  - PromisesObjC (2.1.0)
-  - SwiftLint (0.47.1)
+  - PromisesObjC (2.1.1)
+  - SwiftLint (0.48.0)
 
 DEPENDENCIES:
   - AppCenter (~> 4.3.0)
   - CocoaLumberjack/Swift (~> 3.6.0)
-  - Firebase/Crashlytics (= 8.9.1)
+  - Firebase/Crashlytics (= 9.4.0)
   - Instabug (= 11.0.1)
   - OktaLogger (from `.`)
 
@@ -91,6 +95,7 @@ SPEC REPOS:
     - Firebase
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseInstallations
     - GoogleDataTransport
@@ -107,19 +112,20 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
-  FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
-  FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
-  FirebaseCrashlytics: 40efbd81157dae307ec95612fa1328347284d2c2
-  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
-  GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
+  Firebase: 7703fc4022824b6d6db1bf7bea58d13b8e17ec46
+  FirebaseCore: 9a2b10270a854731c4d4d8a97d0aa8380ec3458d
+  FirebaseCoreDiagnostics: aaa87098082c4d4bdd1a9557b1186d18ca85ce8c
+  FirebaseCoreInternal: a13302b0088fbf5f38b79b6ece49c2af7d3e05d6
+  FirebaseCrashlytics: 121ea1d37f4906c94c4c9307297af5121b98b789
+  FirebaseInstallations: 61db1054e688d2bdc4e2b3f744c1b086e913b742
+  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   Instabug: 66a95bac5cd87725b546456b732893ada4b6aef5
-  nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  OktaLogger: 835e59a3ac8c6fc9fffad304c728e8e82f85e7a7
-  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
-  SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
+  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  OktaLogger: 8530eed1e4b97deb9f31c861114a9dc910053587
+  PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
+  SwiftLint: 284cea64b6187c5d6bd83e9a548a64104d546447
 
-PODFILE CHECKSUM: 99261b14e6088b2e519def3893c4c8808128e0dc
+PODFILE CHECKSUM: 57f64e2f7b16fbd8cbed429da2beadd2b54f88c2
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -56,25 +56,25 @@ PODS:
     - nanopb/encode (= 2.30909.0)
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
-  - OktaLogger (1.4.0):
-    - OktaLogger/Complete (= 1.4.0)
+  - OktaLogger (1.4.1):
+    - OktaLogger/Complete (= 1.4.1)
     - SwiftLint
-  - OktaLogger/Complete (1.4.0):
+  - OktaLogger/Complete (1.4.1):
     - OktaLogger/FileLogger
     - OktaLogger/FirebaseCrashlytics
     - OktaLogger/InstabugLogger
     - SwiftLint
-  - OktaLogger/Core (1.4.0):
+  - OktaLogger/Core (1.4.1):
     - SwiftLint
-  - OktaLogger/FileLogger (1.4.0):
+  - OktaLogger/FileLogger (1.4.1):
     - CocoaLumberjack/Swift (~> 3.6.0)
     - OktaLogger/Core
     - SwiftLint
-  - OktaLogger/FirebaseCrashlytics (1.4.0):
+  - OktaLogger/FirebaseCrashlytics (1.4.1):
     - Firebase/Crashlytics (~> 9.0)
     - OktaLogger/Core
     - SwiftLint
-  - OktaLogger/InstabugLogger (1.4.0):
+  - OktaLogger/InstabugLogger (1.4.1):
     - Instabug (= 11.0.1)
     - OktaLogger/Core
     - SwiftLint
@@ -122,10 +122,10 @@ SPEC CHECKSUMS:
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   Instabug: 66a95bac5cd87725b546456b732893ada4b6aef5
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
-  OktaLogger: 8530eed1e4b97deb9f31c861114a9dc910053587
+  OktaLogger: bc4c06a829743eb448b9ffdccf6124268bc8a4c1
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   SwiftLint: 284cea64b6187c5d6bd83e9a548a64104d546447
 
 PODFILE CHECKSUM: 57f64e2f7b16fbd8cbed429da2beadd2b54f88c2
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.10.2


### PR DESCRIPTION
Part of the ticket [OKTA-521317](https://oktainc.atlassian.net/browse/OKTA-521317) 

Need to update dependencies to use the latest FirebaseSDK in OV (9.4.0)