### PR TITLE
Change info to default in console logger

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.3.12"
+  s.version          = "1.3.13"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"

--- a/Sources/OktaLogger/LoggerCore/OktaLoggerConsoleLogger.swift
+++ b/Sources/OktaLogger/LoggerCore/OktaLoggerConsoleLogger.swift
@@ -38,7 +38,7 @@ public class OktaLoggerConsoleLogger: OktaLoggerDestinationBase {
         case .debug:
             return .debug
         case .info, .uiEvent:
-             return .info
+             return .default
         case .error, .warning:
             return .error
         default:

--- a/Sources/OktaLogger/LoggerCore/OktaLoggerConsoleLogger.swift
+++ b/Sources/OktaLogger/LoggerCore/OktaLoggerConsoleLogger.swift
@@ -25,7 +25,7 @@ public class OktaLoggerConsoleLogger: OktaLoggerDestinationBase {
                                            file: file, line: line, funcName: funcName)
         // translate log level into relevant console type level
         let type = self.consoleLogType(level: level)
-        os_log("%s", type: type, logMessage)
+        os_log("%{public}s", type: type, logMessage)
     }
 
     // MARK: Private + Internal


### PR DESCRIPTION
It seems like, at least in my testing, that info level logs don't get reported to Console, so we should use default (which does get reported to Console) instead.