### PR TITLE
OKTA-573562: Update Firebase to 10.4.0 and Instabug to 11.7.0

### DIFF
--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.3.13"
+  s.version          = "1.3.14"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     crashlytics.source_files = [
       'Sources/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift'
     ]
-    crashlytics.dependency 'Firebase/Crashlytics', '~> 9.0'
+    crashlytics.dependency 'Firebase/Crashlytics', '~> 10.3'
     crashlytics.dependency 'OktaLogger/Core'
   end
 
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
       instabugLogger.ios.source_files = [
         'Sources/OktaLogger/InstabugLogger/*'
       ]
-      instabugLogger.ios.dependency 'Instabug', '11.2.0'
+      instabugLogger.ios.dependency 'Instabug', '~> 11.5'
       instabugLogger.ios.dependency 'OktaLogger/Core'
   end
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "111d8d6ad1a1afd6c8e9561d26e55ab1e74fcb42",
-        "version" : "8.15.0"
+        "revision" : "0df86ea17d5d281415be74f2290df8431644f156",
+        "version" : "10.4.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ef819db8c58657a6ca367322e73f3b6322afe0a2",
-        "version" : "8.15.0"
+        "revision" : "9a09ece724128e8d1e14c5133b87c0e236844ac0",
+        "version" : "10.4.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "4073d04bf28943353b706f461d4ca2a89abb69c1",
-        "version" : "9.1.3"
+        "revision" : "f6b558e3f801f2cac336b04f615ce111fa9ddaa0",
+        "version" : "9.2.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "f4abe56ce62a779e64b525eb133c8fc2a84bbc1f",
-        "version" : "7.7.1"
+        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
+        "version" : "7.11.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
-        "version" : "1.7.2"
+        "revision" : "96d7cc73a71ce950723aa3c50ce4fb275ae180b8",
+        "version" : "3.1.0"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Instabug/Instabug-SP",
       "state" : {
-        "revision" : "bce2d235b194736a7939a3cbe3cb3211844b05a8",
-        "version" : "11.2.0"
+        "revision" : "7d89a79d7d82a1295699f3ca87f95d59b8e91390",
+        "version" : "11.7.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "7ee9ef9f627d85cbe1b8c4f49a3ed26eed216c77",
-        "version" : "2.30908.0"
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ let package = Package(
             targets: ["InstabugLogger"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Instabug/Instabug-SP", .upToNextMajor(from: "11.2.0")),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", .upToNextMajor(from: "8.0.0")),
+        .package(url: "https://github.com/Instabug/Instabug-SP", .upToNextMajor(from: "11.5.0")),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", .upToNextMajor(from: "10.3.0")),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMajor(from: "3.6.0")),
         .package(url: "https://github.com/microsoft/appcenter-sdk-apple.git", .upToNextMajor(from: "4.0.0"))
     ],

--- a/Podfile
+++ b/Podfile
@@ -3,15 +3,15 @@ use_modular_headers!
 
 target 'OktaLogger' do
     pod 'AppCenter', '4.3.0'
-    pod 'Firebase/Crashlytics', '9.4.0'
+    pod 'Firebase/Crashlytics', '10.4.0'
     pod 'CocoaLumberjack/Swift', '~>3.6.0'
-    pod 'Instabug', '11.2.0'
+    pod 'Instabug', '11.7.0'
 end
 
 target 'OktaLoggerDemoApp' do
     pod 'OktaLogger', :path => '.'
     pod 'OktaAnalytics', :path => '.'
-    pod 'Firebase/Crashlytics', '9.4.0'
+    pod 'Firebase/Crashlytics', '10.4.0'
 
     target 'OktaLoggerTests' do
       inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,47 +10,41 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - Firebase/CoreOnly (9.4.0):
-    - FirebaseCore (= 9.4.0)
-  - Firebase/Crashlytics (9.4.0):
+  - Firebase/CoreOnly (10.4.0):
+    - FirebaseCore (= 10.4.0)
+  - Firebase/Crashlytics (10.4.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 9.4.0)
-  - FirebaseCore (9.4.0):
-    - FirebaseCoreDiagnostics (~> 9.0)
-    - FirebaseCoreInternal (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (9.5.0):
-    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/Logger (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCoreInternal (9.5.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.7)"
-  - FirebaseCrashlytics (9.4.0):
-    - FirebaseCore (~> 9.0)
-    - FirebaseInstallations (~> 9.0)
-    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
-    - GoogleUtilities/Environment (~> 7.7)
+    - FirebaseCrashlytics (~> 10.4.0)
+  - FirebaseCore (10.4.0):
+    - FirebaseCoreInternal (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/Logger (~> 7.8)
+  - FirebaseCoreInternal (10.4.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseCrashlytics (10.4.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleDataTransport (~> 9.2)
+    - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseInstallations (9.5.0):
-    - FirebaseCore (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/UserDefaults (~> 7.7)
+  - FirebaseInstallations (10.4.0):
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - GoogleDataTransport (9.2.0):
+  - GoogleDataTransport (9.2.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Environment (7.7.0):
+  - GoogleUtilities/Environment (7.11.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.7.0):
+  - GoogleUtilities/Logger (7.11.0):
     - GoogleUtilities/Environment
-  - "GoogleUtilities/NSData+zlib (7.7.0)"
-  - GoogleUtilities/UserDefaults (7.7.0):
+  - "GoogleUtilities/NSData+zlib (7.11.0)"
+  - GoogleUtilities/UserDefaults (7.11.0):
     - GoogleUtilities/Logger
-  - Instabug (11.2.0)
+  - Instabug (11.7.0)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
     - nanopb/encode (= 2.30909.0)
@@ -59,36 +53,36 @@ PODS:
   - OktaAnalytics (1.0.1):
     - AppCenter (= 4.3.0)
     - OktaLogger/Core (~> 1)
-  - OktaLogger (1.3.12):
-    - OktaLogger/Complete (= 1.3.12)
+  - OktaLogger (1.3.13):
+    - OktaLogger/Complete (= 1.3.13)
     - SwiftLint
-  - OktaLogger/Complete (1.3.12):
+  - OktaLogger/Complete (1.3.13):
     - OktaLogger/FileLogger
     - OktaLogger/FirebaseCrashlytics
     - OktaLogger/InstabugLogger
     - SwiftLint
-  - OktaLogger/Core (1.3.12):
+  - OktaLogger/Core (1.3.13):
     - SwiftLint
-  - OktaLogger/FileLogger (1.3.12):
+  - OktaLogger/FileLogger (1.3.13):
     - CocoaLumberjack/Swift (~> 3.6.0)
     - OktaLogger/Core
     - SwiftLint
-  - OktaLogger/FirebaseCrashlytics (1.3.12):
-    - Firebase/Crashlytics (~> 9.0)
+  - OktaLogger/FirebaseCrashlytics (1.3.13):
+    - Firebase/Crashlytics (~> 10.3)
     - OktaLogger/Core
     - SwiftLint
-  - OktaLogger/InstabugLogger (1.3.12):
-    - Instabug (= 11.2.0)
+  - OktaLogger/InstabugLogger (1.3.13):
+    - Instabug (~> 11.5)
     - OktaLogger/Core
     - SwiftLint
   - PromisesObjC (2.1.1)
-  - SwiftLint (0.49.1)
+  - SwiftLint (0.50.3)
 
 DEPENDENCIES:
   - AppCenter (= 4.3.0)
   - CocoaLumberjack/Swift (~> 3.6.0)
-  - Firebase/Crashlytics (= 9.4.0)
-  - Instabug (= 11.2.0)
+  - Firebase/Crashlytics (= 10.4.0)
+  - Instabug (= 11.7.0)
   - OktaAnalytics (from `.`)
   - OktaLogger (from `.`)
 
@@ -98,7 +92,6 @@ SPEC REPOS:
     - CocoaLumberjack
     - Firebase
     - FirebaseCore
-    - FirebaseCoreDiagnostics
     - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseInstallations
@@ -118,21 +111,20 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  Firebase: 7703fc4022824b6d6db1bf7bea58d13b8e17ec46
-  FirebaseCore: 9a2b10270a854731c4d4d8a97d0aa8380ec3458d
-  FirebaseCoreDiagnostics: 17cbf4e72b1dbd64bfdc33d4b1f07bce4f16f1d8
-  FirebaseCoreInternal: 50a8e39cae8abf72d5145d07ea34c3244f70862b
-  FirebaseCrashlytics: 121ea1d37f4906c94c4c9307297af5121b98b789
-  FirebaseInstallations: 41f811b530c41dd90973d0174381cdb3fcb5e839
-  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
-  GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
-  Instabug: 2153fb2bc805bca730ce97251e3dc6cd04864171
+  Firebase: ba3501b5142a57747eac74d27c96d2b313bdec90
+  FirebaseCore: b8697a177690b69b0dbce9d612b69b893be70469
+  FirebaseCoreInternal: e301297f4c15a17489e48ed722d733b1578e0c02
+  FirebaseCrashlytics: 52e821fd4d36eba20a251a53549c2778b455f360
+  FirebaseInstallations: 36b38c733fd37e50857e5e8d74138648f466f18c
+  GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
+  GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
+  Instabug: 7c9b72efb697e0f11c21ddf74e5d57a2b67ce9f7
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   OktaAnalytics: fb3bd310ed6ace10823e2c822570afa6b7f2f656
-  OktaLogger: 7788647b3748015cc367e3b767d40b0c9e3a391a
+  OktaLogger: 1778edd5a3118e134c868c8c540575b90ea2f7ba
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
+  SwiftLint: 77f7cb2b9bb81ab4a12fcc86448ba3f11afa50c6
 
-PODFILE CHECKSUM: b802960bc460f61959e2fdf12bc8d1bc8085e5e9
+PODFILE CHECKSUM: 3ba1a7f5b9cc7228381cf9c561974268f65e7a6c
 
 COCOAPODS: 1.10.2


### PR DESCRIPTION
Need to update dependencies to use the latest FirebaseSDK (10.4.0) and Instabug SDK (11.7.0) in OV