### PR TITLE
Add OktaSQLiteStorage podspec version

### DIFF
--- a/OktaSQLiteStorage.podspec
+++ b/OktaSQLiteStorage.podspec
@@ -9,7 +9,7 @@ Okta SQLite storage wrapper on top of GRDB framework
   s.homepage         = 'https://github.com/okta/okta-logger-swift.git'
   s.license          = { :type => 'APACHE2', :file => 'LICENSE' }
   s.authors          = { "Okta Developers" => "developer@okta.com" }
-  s.source           = { :git => 'https://github.com/okta/okta-logger-swift.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/okta/okta-logger-swift.git', :tag => "OktaSQLiteStorage-"+s.version.to_s }
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '13.0'


### PR DESCRIPTION
In order to push OktaSQLiteStorage to cocoapods trunk we need to match the right version on the repo. 
- Created tag `OktaSQLiteStorage-.0.0.1`
- Add OktaSQLiteStorage-0.0.1 podspec version