### PR TITLE
OktaSQLiteStorage min OSX version to 11

### DIFF
--- a/OktaSQLiteStorage.podspec
+++ b/OktaSQLiteStorage.podspec
@@ -13,7 +13,7 @@ Okta SQLite storage wrapper on top of GRDB framework
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '13.0'
-  s.osx.deployment_target = '12.0'
+  s.osx.deployment_target = '11.0'
   s.source_files = 'Sources/OktaSQLiteStorage/Sources/*.{h,m,swift}'
 
   s.dependency 'GRDB.swift','~>5'

--- a/OktaSQLiteStorage.podspec
+++ b/OktaSQLiteStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OktaSQLiteStorage'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'Okta SQLite storage framework'
   s.description      = <<-DESC
 Okta SQLite storage wrapper on top of GRDB framework


### PR DESCRIPTION
DeviceSDK has min OSX version to 11, in order to use this pod inside DeviceSDK we need to lower the min version.