### PR TITLE
OKTA-612308 - OktaSQLiteStorage: Add special error for db downgrade cases

### DIFF
--- a/Sources/OktaSQLiteStorage/README.md
+++ b/Sources/OktaSQLiteStorage/README.md
@@ -19,9 +19,10 @@ CREATE TABLE 'Example' (
 
 let schema = SQLiteSchema(schema: queries, version: SchemaVersions.v1)
 
-let sqliteStorageBuilder = SQLiteStorageBuilder()
 let sqliteStorage = try await SQLiteStorageBuilder()
                             .setWALMode(enabled: true)
                             .build(schema: schema, storagePath: dbURL)
+
+try await sqliteStorage.initialize(storageMigrator: SQLiteMigrator())
 
 ```

--- a/Sources/OktaSQLiteStorage/Sources/SQLiteStorageBuilder.swift
+++ b/Sources/OktaSQLiteStorage/Sources/SQLiteStorageBuilder.swift
@@ -42,8 +42,7 @@ public class SQLiteStorageBuilder {
     ///   - storagePath: Location of sqlite database and service files
     /// - Returns: Constructed object that conforms to OktaSQLiteStorageProtocol protocol
     public func build(schema: SQLiteSchema,
-                      storagePath: URL,
-                      storageMigrator: any SQLiteMigratable) async throws -> SQLiteStorageProtocol {
+                      storagePath: URL) async throws -> SQLiteStorageProtocol {
         if schema.version.rawValue == 0 || schema.version.rawValue < 0 {
             throw SQLiteStorageError.generalError("Invalid schema version")
         }
@@ -51,10 +50,7 @@ public class SQLiteStorageBuilder {
         let sqliteStorage = try SQLiteStorage(at: storagePath,
                                               schema: schema,
                                               walModeEnabled: walModeEnabled,
-                                              configuration: configuration,
-                                              storageMigrator: storageMigrator)
-        try await sqliteStorage.initialize()
-
+                                              configuration: configuration)
         return sqliteStorage
     }
 }

--- a/Sources/OktaSQLiteStorage/Sources/SQLiteStorageError.swift
+++ b/Sources/OktaSQLiteStorage/Sources/SQLiteStorageError.swift
@@ -14,6 +14,15 @@ import Foundation
 
 public enum SQLiteStorageError: Error {
     case generalError(String)
+    case migrationError(MigrationError)
     case sqliteError(String)
     case internalError(String)
 }
+
+public enum MigrationError {
+    case badCurrentVersion
+    case badTargetVersion
+    case downgradeAttempt
+}
+
+extension MigrationError: Equatable {}

--- a/Sources/OktaSQLiteStorage/Sources/SQLiteStorageProtocol.swift
+++ b/Sources/OktaSQLiteStorage/Sources/SQLiteStorageProtocol.swift
@@ -20,4 +20,7 @@ public protocol SQLiteStorageProtocol {
 
     /// Location of a database
     var sqliteURL: URL { get }
+
+    /// Asynchronously initializes databases and starts migration if required
+    func initialize(storageMigrator: any SQLiteMigratable) async throws
 }

--- a/Tests/SQLiteStorageTests/SQLiteStorageTests.swift
+++ b/Tests/SQLiteStorageTests/SQLiteStorageTests.swift
@@ -24,7 +24,7 @@ final class SQLiteStorageTests: XCTestCase {
                                                                        includingPropertiesForKeys: nil,
                                                                        options: .skipsHiddenFiles)
             for fileURL in fileURLs {
-                try FileManager.default.removeItem(at: fileURL)
+                try? FileManager.default.removeItem(at: fileURL)
             }
             dbURL = cacheURL.appendingPathComponent("sqlite.db")
         }
@@ -45,7 +45,8 @@ final class SQLiteStorageTests: XCTestCase {
             let schema = SQLiteSchema(schema: schemaQueries, version: SchemaVersions.v1)
             let storage = try await SQLiteStorageBuilder()
                 .setWALMode(enabled: true)
-                .build(schema: schema, storagePath: dbURL, storageMigrator: SQLiteMigratorMock())
+                .build(schema: schema, storagePath: dbURL)
+            try await storage.initialize(storageMigrator: SQLiteMigratorMock())
 
             XCTAssertEqual(storage.sqliteURL, dbURL)
             try await storage.sqlitePool.write { db in
@@ -81,7 +82,8 @@ final class SQLiteStorageTests: XCTestCase {
             let schema = SQLiteSchema(schema: schemaQueries, version: SchemaVersions.v2)
             let storage = try await SQLiteStorageBuilder()
                 .setWALMode(enabled: true)
-                .build(schema: schema, storagePath: dbURL, storageMigrator: SQLiteMigratorMock())
+                .build(schema: schema, storagePath: dbURL)
+            try await storage.initialize(storageMigrator: SQLiteMigratorMock())
 
             try await storage.sqlitePool.write { db in
                 try db.execute(literal: "INSERT INTO Example2 (id) VALUES (5) ")
@@ -100,6 +102,30 @@ final class SQLiteStorageTests: XCTestCase {
         }
         
         wait(for: [readFromDBExpectation, writeToDBExpectation], timeout: 1)
+    }
+
+    func testDBDowngrade() throws {
+        try testMigration()
+        let endOfAsycTest = expectation(description: "End of async test")
+
+        Task {
+            do {
+                let schema = SQLiteSchema(schema: "", version: SchemaVersions.v1)
+                let storage = try await SQLiteStorageBuilder()
+                    .setWALMode(enabled: true)
+                    .build(schema: schema, storagePath: dbURL)
+                try await storage.initialize(storageMigrator: SQLiteMigratorMock())
+            } catch {
+                if case SQLiteStorageError.migrationError(let errorType) = error {
+                    XCTAssertTrue(errorType == .downgradeAttempt)
+                } else {
+                    XCTFail("Unexpected error type")
+                }
+                endOfAsycTest.fulfill()
+            }
+        }
+
+        wait(for: [endOfAsycTest], timeout: 1)
     }
 }
 


### PR DESCRIPTION
For the cases when Storage impl will detect attempt to work with previous versions of db storage will fire `SQLiteStorageError.migrationError(.downgradeAttempt)` error.

It is up to the client how to handle this error type, storage impl doesn't invalidate GRDB handle and it is still valid. If client is confident that integrity of downgraded db schema is not violated then client can start transactional work with db