### PR TITLE
Add SQLCipher support

### DIFF
--- a/OktaLogger.xcodeproj/project.pbxproj
+++ b/OktaLogger.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		806FF25E24B95A3300994D4D /* OktaLoggerFileLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806FF25D24B95A3300994D4D /* OktaLoggerFileLogger.swift */; };
 		80AA110224BE799800981074 /* DemoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA110124BE799800981074 /* DemoTableViewCell.swift */; };
 		8DCF5EB8263CACAD008698CD /* DDLogFileManagerCustomName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCF5EB7263CACAC008698CD /* DDLogFileManagerCustomName.swift */; };
-		9F26660E29F728540064EF50 /* OktaSQLiteStorage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F26660629F728530064EF50 /* OktaSQLiteStorage.framework */; };
 		9F26663029F747490064EF50 /* SQLiteConnectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F26662A29F747490064EF50 /* SQLiteConnectionBuilder.swift */; };
 		9F26663129F747490064EF50 /* SQLitePersistentStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F26662B29F747490064EF50 /* SQLitePersistentStorage.swift */; };
 		9F26663229F747490064EF50 /* SQLiteStorageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F26662C29F747490064EF50 /* SQLiteStorageProtocol.swift */; };
@@ -72,13 +71,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		9F26660F29F728540064EF50 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D5C824CB2469DBF1005CF747 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9F26660529F728530064EF50;
-			remoteInfo = OktaSQLiteStorage;
-		};
 		D54461C4246A02C800C755F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D5C824CB2469DBF1005CF747 /* Project object */;
@@ -222,7 +214,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F26660E29F728540064EF50 /* OktaSQLiteStorage.framework in Frameworks */,
 				267DBA321DB541728E814174 /* libPods-OktaSQLiteStorageTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -587,7 +578,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				9F26661029F728540064EF50 /* PBXTargetDependency */,
 			);
 			name = OktaSQLiteStorageTests;
 			productName = OktaSQLiteStorageTests;
@@ -1137,11 +1127,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		9F26661029F728540064EF50 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 9F26660529F728530064EF50 /* OktaSQLiteStorage */;
-			targetProxy = 9F26660F29F728540064EF50 /* PBXContainerItemProxy */;
-		};
 		D54461C5246A02C800C755F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D5C824D32469DBF1005CF747 /* OktaLogger */;

--- a/OktaSQLiteStorage.podspec
+++ b/OktaSQLiteStorage.podspec
@@ -16,5 +16,6 @@ Okta SQLite storage wrapper on top of GRDB framework
   s.osx.deployment_target = '11.0'
   s.source_files = 'Sources/OktaSQLiteStorage/Sources/*.{h,m,swift}'
 
-  s.dependency 'GRDB.swift','~>5'
+  s.dependency 'GRDB.swift/SQLCipher','~> 5'
+  s.dependency 'SQLCipher','~> 4'
 end

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,8 @@ target 'OktaLogger' do
 end
 
 target 'OktaSQLiteStorage' do
-    pod 'GRDB.swift', '~>5'
+    pod 'GRDB.swift/SQLCipher','~>5'
+    pod 'SQLCipher', '~> 4.0'
     pod 'SwiftLint', '0.51'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,9 +44,8 @@ PODS:
   - "GoogleUtilities/NSData+zlib (7.11.1)"
   - GoogleUtilities/UserDefaults (7.11.1):
     - GoogleUtilities/Logger
-  - GRDB.swift (5.26.1):
-    - GRDB.swift/standard (= 5.26.1)
-  - GRDB.swift/standard (5.26.1)
+  - GRDB.swift/SQLCipher (5.26.1):
+    - SQLCipher (>= 3.4.0)
   - Instabug (11.7.0)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
@@ -74,20 +73,27 @@ PODS:
     - Instabug (~> 11)
     - OktaLogger/Core
   - OktaSQLiteStorage (0.0.3):
-    - GRDB.swift (~> 5)
+    - GRDB.swift/SQLCipher (~> 5)
+    - SQLCipher (~> 4)
   - PromisesObjC (2.2.0)
+  - SQLCipher (4.5.4):
+    - SQLCipher/standard (= 4.5.4)
+  - SQLCipher/common (4.5.4)
+  - SQLCipher/standard (4.5.4):
+    - SQLCipher/common
   - SwiftLint (0.51.0)
 
 DEPENDENCIES:
   - AppCenter (~> 5.0.0)
   - CocoaLumberjack/Swift (~> 3.6.0)
   - Firebase/Crashlytics (~> 10.4.0)
-  - GRDB.swift (~> 5)
+  - GRDB.swift/SQLCipher (~> 5)
   - Instabug (= 11.7.0)
   - OktaAnalytics (from `.`)
   - OktaLogger (from `.`)
   - OktaLogger/Core (from `.`)
   - OktaSQLiteStorage (from `.`)
+  - SQLCipher (~> 4.0)
   - SwiftLint (= 0.51)
 
 SPEC REPOS:
@@ -105,6 +111,7 @@ SPEC REPOS:
     - Instabug
     - nanopb
     - PromisesObjC
+    - SQLCipher
     - SwiftLint
 
 EXTERNAL SOURCES:
@@ -130,10 +137,11 @@ SPEC CHECKSUMS:
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   OktaAnalytics: 27227ae547b3e9f2557ebae9c3e6deefed1ab70d
   OktaLogger: 7839f9c82ef90568708981b3647f315d0dcb37d5
-  OktaSQLiteStorage: 5d85db0ba3185686b466ec4516c709175e72e671
+  OktaSQLiteStorage: ff64e82ec8fac8e6daa63d3e7a765a8108a216bf
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
+  SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
 
-PODFILE CHECKSUM: 51bb971916de2e4f23c89b50357887555dfe8f00
+PODFILE CHECKSUM: bcc5ed902bd6a5fb1601f139761c965581b8f05e
 
 COCOAPODS: 1.12.1

--- a/Sources/OktaSQLiteStorage/Sources/SQLiteConnectionBuilder.swift
+++ b/Sources/OktaSQLiteStorage/Sources/SQLiteConnectionBuilder.swift
@@ -14,20 +14,16 @@ import Foundation
 import GRDB
 
 protocol SQLiteConnectionBuilderProtocol {
-    func databasePool(at databaseURL: URL, walModeEnabled: Bool, configuration: Configuration?) throws -> DatabasePool
+    func databasePool(at databaseURL: URL,
+                      walModeEnabled: Bool,
+                      configuration: Configuration?) throws -> DatabasePool
 }
 
 class SQLiteConnectionBuilder: SQLiteConnectionBuilderProtocol {
+
     func databasePool(at databaseURL: URL,
                       walModeEnabled: Bool,
                       configuration: Configuration?) throws -> DatabasePool {
-        try databasePool(at: databaseURL, sqliteFileEncryptionKey: nil, walModeEnabled: walModeEnabled, configuration: configuration)
-    }
-
-    private func databasePool(at databaseURL: URL,
-                              sqliteFileEncryptionKey: Data?,
-                              walModeEnabled: Bool,
-                              configuration: Configuration?) throws -> DatabasePool {
         var grdbConfiguration: Configuration
         if let configuration = configuration {
             grdbConfiguration = configuration
@@ -50,14 +46,6 @@ class SQLiteConnectionBuilder: SQLiteConnectionBuilderProtocol {
                 guard code == SQLITE_OK else {
                     throw DatabaseError(resultCode: ResultCode(rawValue: code))
                 }
-            }
-
-            if let fileEncryptionKey = sqliteFileEncryptionKey {
-                #if GRDBCIPHER
-                try db.usePassphrase(fileEncryptionKey)
-                #else
-                assertionFailure("fileEncryptionKey is specified for SQLite, while SQLCipher is not integrated. Please, consider to link podspec ending with 'SQLCipher' suffix")
-                #endif
             }
         }
 


### PR DESCRIPTION
SQLCipher is compatible with regular sqlite3 implementation. If you don't provide passphrase then your database will function as vanilla sqlite3 db