### PR TITLE
Fix error handling

### DIFF
--- a/OktaAnalytics.podspec
+++ b/OktaAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaAnalytics"
-  s.version          = "2.2"
+  s.version          = "3.0"
   s.summary          = "Implementation of Analytics logger destination"
   s.description      = "Implementation of Analytics logger destination. Requires OktaLogger/Core"
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/OktaAnalytics/**/*.{h,m,swift}'
   s.dependency 'AppCenter','~>5'
   s.dependency 'OktaLogger/Core', '~>1'
-  s.dependency 'OktaSQLiteStorage', '~>0.0.4'
+  s.dependency 'OktaSQLiteStorage', '~>0.1.0'
   s.dependency 'Firebase/AnalyticsWithoutAdIdSupport'
 end

--- a/OktaSQLiteStorage.podspec
+++ b/OktaSQLiteStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OktaSQLiteStorage'
-  s.version          = '0.0.5'
+  s.version          = '0.1.0'
   s.summary          = 'Okta SQLite storage framework'
   s.description      = <<-DESC
 Okta SQLite storage wrapper on top of GRDB framework

--- a/Sources/OktaSQLiteStorage/Sources/SQLitePersistentStorage.swift
+++ b/Sources/OktaSQLiteStorage/Sources/SQLitePersistentStorage.swift
@@ -45,12 +45,11 @@ class SQLiteStorage: SQLiteStorageProtocol {
             }
             coordinator.coordinate(writingItemAt: sqliteURL, options: .forMerging, error: &coordinatorError, byAccessor: coordinationBlock)
             if let error = dbError ?? coordinatorError {
-                throw SQLiteStorageError.sqliteError(error.localizedDescription)
+                throw error
             }
             self.sqlitePool = dbPool
         } catch {
-            //logger.error(eventName: "Error on sqlitePool initialization", message: "Error: \(error)")
-            throw SQLiteStorageError.sqliteError(error.localizedDescription)
+            throw SQLiteStorageError.sqliteError(error)
         }
     }
 
@@ -79,7 +78,7 @@ class SQLiteStorage: SQLiteStorageProtocol {
         } catch let error as SQLiteStorageError {
             throw error
         } catch {
-            throw SQLiteStorageError.sqliteError(error.localizedDescription)
+            throw SQLiteStorageError.sqliteError(error)
         }
     }
 

--- a/Sources/OktaSQLiteStorage/Sources/SQLiteStorageError.swift
+++ b/Sources/OktaSQLiteStorage/Sources/SQLiteStorageError.swift
@@ -15,7 +15,7 @@ import Foundation
 public enum SQLiteStorageError: Error {
     case generalError(String)
     case migrationError(MigrationError)
-    case sqliteError(String)
+    case sqliteError(Error)
     case internalError(String)
 }
 


### PR DESCRIPTION
Fix error handling:

1. Simplify error propagation to prevent redundant wrapping.
2. Modify the error structure to retain the original database error object.