### PR TITLE
OKTA_1205738 : Replace shared DDLog instance with private instances to prevent debug level logs to merge with error/info/warning logs

### DIFF
--- a/Sources/OktaLogger/FileLoggers/LumberjackLoggerDelegate.swift
+++ b/Sources/OktaLogger/FileLoggers/LumberjackLoggerDelegate.swift
@@ -21,6 +21,7 @@ import CocoaLumberjack
 class LumberjackLoggerDelegate: FileLoggerDelegate {
 
     var fileLogger: DDFileLogger
+    private let ddlog = DDLog()
 
     public init(_ logConfig: OktaLoggerFileLoggerConfig) {
         fileLogger = {
@@ -41,7 +42,7 @@ class LumberjackLoggerDelegate: FileLoggerDelegate {
         if let maxFileSize = logConfig.maximumFileSize {
             fileLogger.maximumFileSize = maxFileSize
         }
-        DDLog.add(fileLogger)
+        ddlog.add(fileLogger)
     }
 
     /**
@@ -117,24 +118,34 @@ class LumberjackLoggerDelegate: FileLoggerDelegate {
      Translate log message into DDLog message
      */
     func log(_ level: OktaLoggerLogLevel, _ message: String) {
-        switch level {
-        case .debug:
-            return DDLogDebug("\(message)")
-        case .info, .uiEvent:
-            return DDLogInfo("\(message)")
-        case .error:
-            return DDLogError("\(message)")
-        case .warning:
-            return DDLogWarn("\(message)")
-        default:
-            return DDLogInfo("\(message)")
-        }
+        let (ddLevel, ddFlag): (DDLogLevel, DDLogFlag) = {
+            switch level {
+            case .debug:          return (.debug, .debug)
+            case .info, .uiEvent: return (.info, .info)
+            case .error:          return (.error, .error)
+            case .warning:        return (.warning, .warning)
+            default:              return (.info, .info)
+            }
+        }()
+        let logMessage = DDLogMessage(
+            message: message,
+            level: ddLevel,
+            flag: ddFlag,
+            context: 0,
+            file: #file,
+            function: nil,
+            line: 0,
+            tag: nil,
+            options: .copyFile,
+            timestamp: nil
+        )
+        ddlog.log(asynchronous: true, message: logMessage)
     }
 
     /**
      Remove all Loggers during deallocate
      */
     deinit {
-        DDLog.remove(fileLogger)
+        ddlog.remove(fileLogger)
     }
 }

--- a/Tests/OktaLoggerTests/OktaLoggerFileLoggerTests.swift
+++ b/Tests/OktaLoggerTests/OktaLoggerFileLoggerTests.swift
@@ -170,6 +170,42 @@ class OktaLoggerFileLoggerTests: XCTestCase {
         wait(for: [expectation], timeout: 20)
     }
     
+    func testDebugMessageDoesNotLeakToErrorLog() {
+        let debugFileLogger = OktaLoggerFileLogger(
+            logConfig: FileTestsHelper.defaultFileConfig,
+            identifier: "com.test.debug",
+            level: .all,
+            defaultProperties: nil
+        )
+        let errorFileLogger = OktaLoggerFileLogger(
+            logConfig: FileTestsHelper.defaultFileConfig,
+            identifier: "com.test.error",
+            level: .error,
+            defaultProperties: nil
+        )
+
+        let logger = OktaLogger(destinations: [debugFileLogger, errorFileLogger])
+
+        // Log a debug message — OktaLogger correctly sends this only to debugFileLogger
+        // but the shared DDLog bus leaks it into errorFileLogger's file
+        logger.debug(eventName: "TEST", message: "debug only message")
+
+        let expectation = XCTestExpectation(description: "Error log should not contain debug message")
+
+        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 3) {
+            errorFileLogger.getLogs { logs in
+                let allContent = logs.compactMap { String(data: $0, encoding: .utf8) }.joined()
+                XCTAssertFalse(
+                    allContent.contains("debug only message"),
+                    "Debug message leaked into error log — shared DDLog bus bug"
+                )
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 15)
+    }
+
     private func pollForLogCompletion(delegate: FileLoggerDelegate, expectedMessages: [String], expectation: XCTestExpectation) {
         DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 3) {
             delegate.getLogs { result in


### PR DESCRIPTION
Fix shared DDLog bus and replacing them with private instances to prevent debug level logs to merge with error/info/warning logs.

## Problem
When multiple `OktaLoggerFileLogger` instances were registered with different log levels, debug messages were incorrectly appearing in the error log file.
  
This happened because `LumberjackLoggerDelegate` used global DDLog functions (`DDLogDebug`, `DDLogInfo` etc.) which route through `DDLog.sharedInstance` —a  process-wide singleton. Since all delegates registered their file loggers with the same shared instance, every message was sent out to all file loggers irrespective of their type.

  
## Fix
Replace `DDLog.sharedInstance` with a `private let ddlog = DDLog()` instance per `LumberjackLoggerDelegate`. Each delegate now has its own isolated bus, so messages can only reach the one file logger belonging to that specific delegate.
  
## Changes
- `LumberjackLoggerDelegate.swift`: Add private DDLog instance, register/unregister with private instance, replace global DDLog functions with explicit `ddlog.log(message:)`
- `OktaLoggerFileLoggerTests.swift`: Add `testDebugMessageDoesNotLeakToErrorLog` to reproduce and verify the fix

 ## Testing
  - Added `testDebugMessageDoesNotLeakToErrorLog` which fails before the fix and passes after
  - All existing file logger tests continue to pass
  
 Before the fix : 
<img width="412" height="225" alt="Screenshot 2026-08-10 at 8 16 33 PM" src="https://github.com/user-attachments/assets/7c0e5b19-1948-4c0c-b7b0-1ca4ca6bfc1c" />

`testDebugMessageDoesNotLeakToErrorLog` was failing due to debug level log being leaked into error logs

After the fix : `testDebugMessageDoesNotLeakToErrorLog` succeeded