### PR TITLE
Fix Snyk auth failure by adding missing step-load-dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
       - run:
           name: run swift package show dependencies
           command: swift package show-dependencies
+      - general-platform-helpers/step-load-dependencies
       - general-platform-helpers/step-run-snyk-monitor:
           scan-all-projects: true
           skip-unresolved: false


### PR DESCRIPTION
Fix Snyk `execute-snyk` job failing with `authentication failed (timeout)`.

Root cause: `step-run-snyk-monitor` was called without `step-load-dependencies` preceding it. Without that step, the Snyk CLI has no token from the `static-analysis` context and falls back to interactive OAuth, which times out in CI.

Fix: add `step-load-dependencies` before `step-run-snyk-monitor` - matches the working pattern in okta-idx-swift and okta-storage-swift.